### PR TITLE
[Feature] designsystem에 커스텀 네비게이션을 추가했습니다.

### DIFF
--- a/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		5E5B0BD32C3289D500936435 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5B0BD22C3289D500936435 /* UIColor+.swift */; };
 		5E5B0BD52C328A1000936435 /* CustomText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5B0BD42C328A1000936435 /* CustomText.swift */; };
 		825665792C35202E0018C799 /* MenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825665782C35202E0018C799 /* MenuViewModel.swift */; };
+		825668A52C367ED30066B216 /* CustomNavBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825668A42C367ED30066B216 /* CustomNavBarModifier.swift */; };
+		825668A72C367F130066B216 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825668A62C367F130066B216 /* View+.swift */; };
+		825668A92C36855A0066B216 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825668A82C36855A0066B216 /* UINavigationController+.swift */; };
 		8274CF332C33D59400FBFA9D /* Scene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8274CF322C33D59400FBFA9D /* Scene.swift */; };
 		8274CF352C33D6C200FBFA9D /* SceneCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8274CF342C33D6C200FBFA9D /* SceneCoordinator.swift */; };
 		8274CF372C33D6D600FBFA9D /* SceneCoordinatorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8274CF362C33D6D600FBFA9D /* SceneCoordinatorType.swift */; };
@@ -28,6 +31,9 @@
 		5E5B0BD22C3289D500936435 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		5E5B0BD42C328A1000936435 /* CustomText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomText.swift; sourceTree = "<group>"; };
 		825665782C35202E0018C799 /* MenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewModel.swift; sourceTree = "<group>"; };
+		825668A42C367ED30066B216 /* CustomNavBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavBarModifier.swift; sourceTree = "<group>"; };
+		825668A62C367F130066B216 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
+		825668A82C36855A0066B216 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
 		8274CF322C33D59400FBFA9D /* Scene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scene.swift; sourceTree = "<group>"; };
 		8274CF342C33D6C200FBFA9D /* SceneCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinator.swift; sourceTree = "<group>"; };
 		8274CF362C33D6D600FBFA9D /* SceneCoordinatorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinatorType.swift; sourceTree = "<group>"; };
@@ -72,6 +78,8 @@
 			children = (
 				5E5B0BD02C3289B800936435 /* UIFont+.swift */,
 				5E5B0BD22C3289D500936435 /* UIColor+.swift */,
+				825668A62C367F130066B216 /* View+.swift */,
+				825668A82C36855A0066B216 /* UINavigationController+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -150,6 +158,14 @@
 			path = Calendar;
 			sourceTree = "<group>";
 		};
+		825668A12C3672C80066B216 /* Modifiers */ = {
+			isa = PBXGroup;
+			children = (
+				825668A42C367ED30066B216 /* CustomNavBarModifier.swift */,
+			);
+			path = Modifiers;
+			sourceTree = "<group>";
+		};
 		8274CF2F2C33D3DB00FBFA9D /* Coordinator */ = {
 			isa = PBXGroup;
 			children = (
@@ -181,6 +197,7 @@
 			children = (
 				82D4D6132C327BDC00A92327 /* HongikYeolgong2_iOSApp.swift */,
 				82D4D6152C327BDC00A92327 /* ContentView.swift */,
+				825668A12C3672C80066B216 /* Modifiers */,
 				8274CF2F2C33D3DB00FBFA9D /* Coordinator */,
 				5E5B0BC82C3286EB00936435 /* Scene */,
 				5E5B0BC72C3286C500936435 /* Font */,
@@ -271,9 +288,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				825668A92C36855A0066B216 /* UINavigationController+.swift in Sources */,
 				8274CF392C33DB1000FBFA9D /* HomeView.swift in Sources */,
 				82D4D6162C327BDC00A92327 /* ContentView.swift in Sources */,
 				8274CF372C33D6D600FBFA9D /* SceneCoordinatorType.swift in Sources */,
+				825668A52C367ED30066B216 /* CustomNavBarModifier.swift in Sources */,
+				825668A72C367F130066B216 /* View+.swift in Sources */,
 				825665792C35202E0018C799 /* MenuViewModel.swift in Sources */,
 				5E5B0BD32C3289D500936435 /* UIColor+.swift in Sources */,
 				5E5B0BD12C3289B800936435 /* UIFont+.swift in Sources */,
@@ -341,7 +361,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -398,7 +418,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -413,28 +433,35 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"HongikYeolgong2-iOS/Preview Content\"";
 				DEVELOPMENT_TEAM = P4D4ZQC4YF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "홍익열공이";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.teamHY2.HongikYeolgong2-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = com.teamHY2.HongikYeolgong2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -443,28 +470,35 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"HongikYeolgong2-iOS/Preview Content\"";
 				DEVELOPMENT_TEAM = P4D4ZQC4YF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "홍익열공이";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.teamHY2.HongikYeolgong2-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = com.teamHY2.HongikYeolgong2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/HongikYeolgong2-iOS/Coordinator/Scene.swift
+++ b/HongikYeolgong2-iOS/Coordinator/Scene.swift
@@ -10,7 +10,6 @@ import Foundation
 enum SceneType: Hashable {
     case loginOnboarding
     case home
-    case menu(MenuViewModel)
 }
 
 extension SceneType {
@@ -24,8 +23,6 @@ extension SceneType {
             hasher.combine("home")
         case .loginOnboarding:
             hasher.combine("login")
-        case .menu:
-            hasher.combine("menu")
         }
     }
 }
@@ -35,7 +32,7 @@ enum FullScreenType: String, Identifiable {
         self.rawValue
     }
     
-    case test
+    case menu
 }
 enum SheetType: String, Identifiable {
     var id: String {

--- a/HongikYeolgong2-iOS/Coordinator/SceneCoordinator.swift
+++ b/HongikYeolgong2-iOS/Coordinator/SceneCoordinator.swift
@@ -47,8 +47,6 @@ final class SceneCoordinator: ObservableObject {
             HomeView()
         case .loginOnboarding:
             LoginView()
-        case .menu(let viewModel):
-            MenuView(viewModel: viewModel)
         }
     }
     
@@ -63,8 +61,8 @@ final class SceneCoordinator: ObservableObject {
     @ViewBuilder
     func buildScreen(fullScreen: FullScreenType) -> some View {
         switch fullScreen {
-        case .test:
-            Text("FullScreen test!")
+        case .menu:
+            MenuView()
         }
     }
 }

--- a/HongikYeolgong2-iOS/Extension/UINavigationController+.swift
+++ b/HongikYeolgong2-iOS/Extension/UINavigationController+.swift
@@ -1,0 +1,16 @@
+//
+//  UINavigationViewController+.swift
+//  HongikYeolgong2-iOS
+//
+//  Created by 석기권 on 7/4/24.
+//
+
+import UIKit
+
+extension UINavigationController: UIGestureRecognizerDelegate {
+    // 커스텀 네비게이션을 사용하는 경우 제스처가 먹히지 않는 문제방지
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+}

--- a/HongikYeolgong2-iOS/Extension/View+.swift
+++ b/HongikYeolgong2-iOS/Extension/View+.swift
@@ -1,0 +1,90 @@
+//
+//  View+.swift
+//  HongikYeolgong2-iOS
+//
+//  Created by 석기권 on 7/4/24.
+//
+
+import SwiftUI
+
+extension View {
+    /// 이 메서드는 지정된 뷰를 포함하는 커스텀 네비게이션 컨테이너를 반환합니다. 네비게이션 바의 타이틀과 백 버튼의 동작 등을 설정할 수 있습니다.
+    /// - Parameters:
+    ///   - center: 중앙에 표시될 뷰입니다.
+    ///   - left: 좌측에 표시될 뷰입니다.
+    ///   - right: 우측에 표시될 뷰입니다.
+    /// - Returns: 커스텀 네비게이션을 포함하는 뷰를 반환합니다.
+    func customNavigation<C, L, R> (
+        center: @escaping (() -> C),
+        left: @escaping (() -> L),
+        right: @escaping (() -> R)
+    ) -> some View where C: View, L: View, R: View {
+        modifier(CustomNavBarModifier(center: center, left: left, right: right))
+    }
+    
+    /// 이 메서드는 지정된 뷰를 포함하는 커스텀 네비게이션 컨테이너를 반환합니다. 네비게이션 바의 타이틀과 백 버튼의 동작 등을 설정할 수 있습니다.
+    /// - Parameters:
+    ///   - center: 중앙에 표시될 뷰입니다.
+    ///   - right: 우측에 표시될 뷰입니다.
+    /// - Returns: 커스텀 네비게이션을 포함하는 뷰를 반환합니다.
+    func customNavigation<C, R> (
+        center: @escaping (() -> C),
+        right: @escaping (() -> R)
+    ) -> some View where C: View, R: View {
+        modifier(CustomNavBarModifier(center: center, right: right))
+    }
+    
+    /// 이 메서드는 지정된 뷰를 포함하는 커스텀 네비게이션 컨테이너를 반환합니다. 네비게이션 바의 타이틀과 백 버튼의 동작 등을 설정할 수 있습니다.
+    /// - Parameters:
+    ///   - center: 중앙에 표시될 뷰입니다.
+    ///   - left: 좌측에 표시될 뷰입니다.s
+    /// - Returns: 커스텀 네비게이션을 포함하는 뷰를 반환합니다.
+    func customNavigation<C, L> (
+        center: @escaping (() -> C),
+        left: @escaping (() -> L)
+    ) -> some View where C: View, L: View {
+        modifier(CustomNavBarModifier(center: center, left: left))
+    }
+    
+    /// 이 메서드는 지정된 뷰를 포함하는 커스텀 네비게이션 컨테이너를 반환합니다. 네비게이션 바의 타이틀과 백 버튼의 동작 등을 설정할 수 있습니다.
+    /// - Parameters:
+    ///   - center: 중앙에 표시될 뷰입니다.
+    /// - Returns: 커스텀 네비게이션을 포함하는 뷰를 반환합니다.
+    func customNavigation<C> (
+        center: @escaping (() -> C)
+    ) -> some View where C: View {
+        modifier(CustomNavBarModifier(center: center))
+    }
+    
+    /// 이 메서드는 지정된 뷰를 포함하는 커스텀 네비게이션 컨테이너를 반환합니다. 네비게이션 바의 타이틀과 백 버튼의 동작 등을 설정할 수 있습니다.
+    /// - Parameters:
+    ///   - left: 좌측에 표시될 뷰입니다.
+    /// - Returns: 커스텀 네비게이션을 포함하는 뷰를 반환합니다.
+    func customNavigation<L> (
+        left: @escaping (() -> L)
+    ) -> some View where L: View {
+        modifier(CustomNavBarModifier(left: left))
+    }
+    
+    /// 이 메서드는 지정된 뷰를 포함하는 커스텀 네비게이션 컨테이너를 반환합니다. 네비게이션 바의 타이틀과 백 버튼의 동작 등을 설정할 수 있습니다.
+    /// - Parameters:
+    ///   - right: 우측에 표시될 뷰입니다.
+    /// - Returns: 커스텀 네비게이션을 포함하는 뷰를 반환합니다.
+    func customNavigation<R> (
+        right: @escaping (() -> R)
+    ) -> some View where R: View {
+        modifier(CustomNavBarModifier(right: right))
+    }
+    
+    /// 이 메서드는 지정된 뷰를 포함하는 커스텀 네비게이션 컨테이너를 반환합니다. 네비게이션 바의 타이틀과 백 버튼의 동작 등을 설정할 수 있습니다.
+    /// - Parameters:
+    ///   - left: 좌측에 표시될 뷰입니다.
+    ///   - right: 우측에 표시될 뷰입니다.
+    /// - Returns: 커스텀 네비게이션을 포함하는 뷰를 반환합니다.
+    func customNavigation<L, R> (
+        left: @escaping (() -> L),
+        right: @escaping (() -> R)
+    ) -> some View where L: View, R: View{
+        modifier(CustomNavBarModifier(left: left, right: right))
+    }
+}

--- a/HongikYeolgong2-iOS/Modifiers/CustomNavBarModifier.swift
+++ b/HongikYeolgong2-iOS/Modifiers/CustomNavBarModifier.swift
@@ -1,0 +1,52 @@
+//
+//  CustomNavBarModifier.swift
+//  HongikYeolgong2-iOS
+//
+//  Created by 석기권 on 7/4/24.
+//
+
+import SwiftUI
+
+/// 커스텀 네비게이션 컨테이너를 생성하는 구현체 입니다.
+struct CustomNavBarModifier<C, L, R>: ViewModifier where C: View, L: View, R: View {
+    let center: (() ->C)?
+    let left: (() -> L)?
+    let right: (() -> R)?
+    
+    init(center: (() -> C)? = {EmptyView()}, left: (()-> L)? = {EmptyView()}, right: (()-> R)? = {EmptyView()}) {
+        self.center = center
+        self.left = left
+        self.right = right
+    }
+    
+    func body(content: Content) -> some View {
+        VStack {
+            ZStack {
+                HStack {
+                    left?()
+                    Spacer()
+                    right?()
+                }
+                .frame(height: 52)
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 16)
+                
+                HStack {
+                    Spacer()
+                    center?()
+                    Spacer()
+                }
+            }
+            .background(.black)
+            .foregroundColor(.white)
+            
+            Spacer()
+            
+            content
+            
+            Spacer()
+        }
+                
+        .navigationBarHidden(true)
+    }
+}

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -13,25 +13,17 @@ struct HomeView: View {
     var body: some View {
         NavigationStack(path: $coordinator.paths) {
             VStack {
-                Text("Home View 🏠")
                 Button(action: {
-                    coordinator.push(.menu(MenuViewModel()))
+                    coordinator.present(fullScreen: .menu)
                 }, label: {
-                    Text("Go to menu")
+                    Text("Go to menu ⚙️")
                 })
-                
-                Button(action: {
-                    coordinator.present(sheet: .test)
-                }) {
-                    Text("Sheet")
-                }
-                
-                Button(action: {
-                    coordinator.present(fullScreen: .test)
-                }) {
-                    Text("FullScreen")
-                }
-            }            
+            }
+            .customNavigation(left: {
+                Text("홍익열공이")
+            }, right: {
+                Image(systemName: "line.3.horizontal")
+            })
             .navigationDestination(for: SceneType.self) { scene in
                 coordinator.buildScreen(scene: scene)
             }

--- a/HongikYeolgong2-iOS/Scene/Menu/MenuView.swift
+++ b/HongikYeolgong2-iOS/Scene/Menu/MenuView.swift
@@ -8,25 +8,22 @@
 import SwiftUI
 
 struct MenuView: View {
-    @StateObject private var loginManager = LoginManager.shared
     @EnvironmentObject private var coordinator: SceneCoordinator
-    @ObservedObject var viewModel: MenuViewModel
     
     var body: some View {
         VStack {
-            Text("Menu View ⚙️")
-            Text("\(viewModel.title)")
-            
-            Button(action: {
-                coordinator.popToRoot()
-                loginManager.logout()
-            }, label: {
-                Text("Logout test")
-            })
+           Text("Menu View")
         }
+        .customNavigation(right: {
+            Button(action: {
+                coordinator.dismissFullScreenCover()
+            }, label: {
+                Image(systemName: "xmark")
+            })
+        })
     }
 }
 
 #Preview {
-    MenuView(viewModel: MenuViewModel())
+    MenuView()
 }


### PR DESCRIPTION
## AS-IS
기본으로 제공되는 네비게이션을 사용하는 경우 커스텀이 자유롭지 못하고 디자인의 일관성을 유지하기 어렵습니다.
## TO-BE
designsystem에 커스텀 네비게이션을 추가합으로써 디자인의 일관성을 유지할 수 있으며
디자인이 변경됬을때 구현체만 수정하면 되기떄문에 작업의 효울성 또한 증가합니다.
## KEY-POINT
구현할때 고려한점
- left, center, right에 Item을 자유롭게 배치 가능
- 단일 파일에서 디자인을 수정
- swipe back 가능 여부

파일 구성
CustomNavModifier(구현체)
customNavigation -> View Extension에 method overloading

customNavigation 메서드에 Quick Help를 생성해두었습니다.
## SCREENSHOT (Optional)
