### PR TITLE
[Feature] 공통으로 사용되는 Dialog 컴포넌트를 만듭니다.

### DIFF
--- a/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		827DC0742C39943200E88069 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 827DC0642C39943200E88069 /* Pretendard-Medium.otf */; };
 		827DC0752C39943200E88069 /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = 827DC0652C39943200E88069 /* Pretendard-Black.otf */; };
 		827DC0762C39943200E88069 /* SUITE-Heavy.otf in Resources */ = {isa = PBXBuildFile; fileRef = 827DC0662C39943200E88069 /* SUITE-Heavy.otf */; };
+		828FF2B32C3E71F1001A4ADE /* DialogModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828FF2B22C3E71F1001A4ADE /* DialogModifier.swift */; };
 		82B1FE7B2C3BC567002D9163 /* Quote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B1FE7A2C3BC567002D9163 /* Quote.swift */; };
 		82B1FE812C3C1755002D9163 /* CustomButton2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B1FE802C3C1755002D9163 /* CustomButton2.swift */; };
 		82B1FE832C3C1BCD002D9163 /* TimeLapse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B1FE822C3C1BCD002D9163 /* TimeLapse.swift */; };
@@ -80,6 +81,7 @@
 		827DC0642C39943200E88069 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Medium.otf"; path = "../../../font/Pretendard-Medium.otf"; sourceTree = "<group>"; };
 		827DC0652C39943200E88069 /* Pretendard-Black.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Black.otf"; path = "../../../font/Pretendard-Black.otf"; sourceTree = "<group>"; };
 		827DC0662C39943200E88069 /* SUITE-Heavy.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-Heavy.otf"; path = "../../../font/SUITE-Heavy.otf"; sourceTree = "<group>"; };
+		828FF2B22C3E71F1001A4ADE /* DialogModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogModifier.swift; sourceTree = "<group>"; };
 		82B1FE7A2C3BC567002D9163 /* Quote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quote.swift; sourceTree = "<group>"; };
 		82B1FE802C3C1755002D9163 /* CustomButton2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton2.swift; sourceTree = "<group>"; };
 		82B1FE822C3C1BCD002D9163 /* TimeLapse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeLapse.swift; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 			isa = PBXGroup;
 			children = (
 				825668A42C367ED30066B216 /* CustomNavBarModifier.swift */,
+				828FF2B22C3E71F1001A4ADE /* DialogModifier.swift */,
 			);
 			path = Modifiers;
 			sourceTree = "<group>";
@@ -386,6 +389,7 @@
 				5E5CD4412C369994002CE244 /* UIScreen+.swift in Sources */,
 				8274CF3D2C33DE2300FBFA9D /* MenuView.swift in Sources */,
 				8274CF352C33D6C200FBFA9D /* SceneCoordinator.swift in Sources */,
+				828FF2B32C3E71F1001A4ADE /* DialogModifier.swift in Sources */,
 				8274CF3B2C33DBC800FBFA9D /* LoginView.swift in Sources */,
 				82B1FE832C3C1BCD002D9163 /* TimeLapse.swift in Sources */,
 				5E5B0BD52C328A1000936435 /* CustomText.swift in Sources */,

--- a/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		828FF2B32C3E71F1001A4ADE /* DialogModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828FF2B22C3E71F1001A4ADE /* DialogModifier.swift */; };
 		82AB4F1D2C3EBF5400787B3B /* AlertModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AB4F1C2C3EBF5400787B3B /* AlertModifier.swift */; };
 		82AB4F212C3EE9DB00787B3B /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AB4F202C3EE9DB00787B3B /* HomeViewModel.swift */; };
+		82AB4F232C3EEE6D00787B3B /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AB4F222C3EEE6D00787B3B /* Date+.swift */; };
 		82B1FE7B2C3BC567002D9163 /* Quote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B1FE7A2C3BC567002D9163 /* Quote.swift */; };
 		82B1FE812C3C1755002D9163 /* CustomButton2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B1FE802C3C1755002D9163 /* CustomButton2.swift */; };
 		82B1FE832C3C1BCD002D9163 /* TimeLapse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B1FE822C3C1BCD002D9163 /* TimeLapse.swift */; };
@@ -86,6 +87,7 @@
 		828FF2B22C3E71F1001A4ADE /* DialogModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogModifier.swift; sourceTree = "<group>"; };
 		82AB4F1C2C3EBF5400787B3B /* AlertModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertModifier.swift; sourceTree = "<group>"; };
 		82AB4F202C3EE9DB00787B3B /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		82AB4F222C3EEE6D00787B3B /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		82B1FE7A2C3BC567002D9163 /* Quote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quote.swift; sourceTree = "<group>"; };
 		82B1FE802C3C1755002D9163 /* CustomButton2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton2.swift; sourceTree = "<group>"; };
 		82B1FE822C3C1BCD002D9163 /* TimeLapse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeLapse.swift; sourceTree = "<group>"; };
@@ -131,6 +133,7 @@
 				5E5CD4402C369994002CE244 /* UIScreen+.swift */,
 				825668A62C367F130066B216 /* View+.swift */,
 				825668A82C36855A0066B216 /* UINavigationController+.swift */,
+				82AB4F222C3EEE6D00787B3B /* Date+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -393,6 +396,7 @@
 				5E5B0BD32C3289D500936435 /* UIColor+.swift in Sources */,
 				8274CF332C33D59400FBFA9D /* Scene.swift in Sources */,
 				82D4D6142C327BDC00A92327 /* HongikYeolgong2_iOSApp.swift in Sources */,
+				82AB4F232C3EEE6D00787B3B /* Date+.swift in Sources */,
 				5E5CD4412C369994002CE244 /* UIScreen+.swift in Sources */,
 				8274CF3D2C33DE2300FBFA9D /* MenuView.swift in Sources */,
 				8274CF352C33D6C200FBFA9D /* SceneCoordinator.swift in Sources */,

--- a/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		827DC0762C39943200E88069 /* SUITE-Heavy.otf in Resources */ = {isa = PBXBuildFile; fileRef = 827DC0662C39943200E88069 /* SUITE-Heavy.otf */; };
 		828FF2B32C3E71F1001A4ADE /* DialogModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828FF2B22C3E71F1001A4ADE /* DialogModifier.swift */; };
 		82AB4F1D2C3EBF5400787B3B /* AlertModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AB4F1C2C3EBF5400787B3B /* AlertModifier.swift */; };
+		82AB4F212C3EE9DB00787B3B /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AB4F202C3EE9DB00787B3B /* HomeViewModel.swift */; };
 		82B1FE7B2C3BC567002D9163 /* Quote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B1FE7A2C3BC567002D9163 /* Quote.swift */; };
 		82B1FE812C3C1755002D9163 /* CustomButton2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B1FE802C3C1755002D9163 /* CustomButton2.swift */; };
 		82B1FE832C3C1BCD002D9163 /* TimeLapse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B1FE822C3C1BCD002D9163 /* TimeLapse.swift */; };
@@ -84,6 +85,7 @@
 		827DC0662C39943200E88069 /* SUITE-Heavy.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-Heavy.otf"; path = "../../../font/SUITE-Heavy.otf"; sourceTree = "<group>"; };
 		828FF2B22C3E71F1001A4ADE /* DialogModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogModifier.swift; sourceTree = "<group>"; };
 		82AB4F1C2C3EBF5400787B3B /* AlertModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertModifier.swift; sourceTree = "<group>"; };
+		82AB4F202C3EE9DB00787B3B /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		82B1FE7A2C3BC567002D9163 /* Quote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quote.swift; sourceTree = "<group>"; };
 		82B1FE802C3C1755002D9163 /* CustomButton2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton2.swift; sourceTree = "<group>"; };
 		82B1FE822C3C1BCD002D9163 /* TimeLapse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeLapse.swift; sourceTree = "<group>"; };
@@ -205,6 +207,7 @@
 			isa = PBXGroup;
 			children = (
 				8274CF382C33DB1000FBFA9D /* HomeView.swift */,
+				82AB4F202C3EE9DB00787B3B /* HomeViewModel.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -380,6 +383,7 @@
 				8274CF392C33DB1000FBFA9D /* HomeView.swift in Sources */,
 				82D4D6162C327BDC00A92327 /* ContentView.swift in Sources */,
 				82B1FE7B2C3BC567002D9163 /* Quote.swift in Sources */,
+				82AB4F212C3EE9DB00787B3B /* HomeViewModel.swift in Sources */,
 				8274CF372C33D6D600FBFA9D /* SceneCoordinatorType.swift in Sources */,
 				825668A52C367ED30066B216 /* CustomNavBarModifier.swift in Sources */,
 				825668A72C367F130066B216 /* View+.swift in Sources */,

--- a/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		827DC0752C39943200E88069 /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = 827DC0652C39943200E88069 /* Pretendard-Black.otf */; };
 		827DC0762C39943200E88069 /* SUITE-Heavy.otf in Resources */ = {isa = PBXBuildFile; fileRef = 827DC0662C39943200E88069 /* SUITE-Heavy.otf */; };
 		828FF2B32C3E71F1001A4ADE /* DialogModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828FF2B22C3E71F1001A4ADE /* DialogModifier.swift */; };
+		82AB4F1D2C3EBF5400787B3B /* AlertModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AB4F1C2C3EBF5400787B3B /* AlertModifier.swift */; };
 		82B1FE7B2C3BC567002D9163 /* Quote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B1FE7A2C3BC567002D9163 /* Quote.swift */; };
 		82B1FE812C3C1755002D9163 /* CustomButton2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B1FE802C3C1755002D9163 /* CustomButton2.swift */; };
 		82B1FE832C3C1BCD002D9163 /* TimeLapse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B1FE822C3C1BCD002D9163 /* TimeLapse.swift */; };
@@ -82,6 +83,7 @@
 		827DC0652C39943200E88069 /* Pretendard-Black.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Black.otf"; path = "../../../font/Pretendard-Black.otf"; sourceTree = "<group>"; };
 		827DC0662C39943200E88069 /* SUITE-Heavy.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-Heavy.otf"; path = "../../../font/SUITE-Heavy.otf"; sourceTree = "<group>"; };
 		828FF2B22C3E71F1001A4ADE /* DialogModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogModifier.swift; sourceTree = "<group>"; };
+		82AB4F1C2C3EBF5400787B3B /* AlertModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertModifier.swift; sourceTree = "<group>"; };
 		82B1FE7A2C3BC567002D9163 /* Quote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quote.swift; sourceTree = "<group>"; };
 		82B1FE802C3C1755002D9163 /* CustomButton2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton2.swift; sourceTree = "<group>"; };
 		82B1FE822C3C1BCD002D9163 /* TimeLapse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeLapse.swift; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 			children = (
 				825668A42C367ED30066B216 /* CustomNavBarModifier.swift */,
 				828FF2B22C3E71F1001A4ADE /* DialogModifier.swift */,
+				82AB4F1C2C3EBF5400787B3B /* AlertModifier.swift */,
 			);
 			path = Modifiers;
 			sourceTree = "<group>";
@@ -391,6 +394,7 @@
 				8274CF352C33D6C200FBFA9D /* SceneCoordinator.swift in Sources */,
 				828FF2B32C3E71F1001A4ADE /* DialogModifier.swift in Sources */,
 				8274CF3B2C33DBC800FBFA9D /* LoginView.swift in Sources */,
+				82AB4F1D2C3EBF5400787B3B /* AlertModifier.swift in Sources */,
 				82B1FE832C3C1BCD002D9163 /* TimeLapse.swift in Sources */,
 				5E5B0BD52C328A1000936435 /* CustomText.swift in Sources */,
 			);

--- a/HongikYeolgong2-iOS.xcodeproj/xcshareddata/xcschemes/HongikYeolgong2-iOS.xcscheme
+++ b/HongikYeolgong2-iOS.xcodeproj/xcshareddata/xcschemes/HongikYeolgong2-iOS.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "82D4D60F2C327BDC00A92327"
+               BuildableName = "HongikYeolgong2-iOS.app"
+               BlueprintName = "HongikYeolgong2-iOS"
+               ReferencedContainer = "container:HongikYeolgong2-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "82D4D60F2C327BDC00A92327"
+            BuildableName = "HongikYeolgong2-iOS.app"
+            BlueprintName = "HongikYeolgong2-iOS"
+            ReferencedContainer = "container:HongikYeolgong2-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "82D4D60F2C327BDC00A92327"
+            BuildableName = "HongikYeolgong2-iOS.app"
+            BlueprintName = "HongikYeolgong2-iOS"
+            ReferencedContainer = "container:HongikYeolgong2-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/HongikYeolgong2-iOS.xcodeproj/xcuserdata/seokkikwon.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/HongikYeolgong2-iOS.xcodeproj/xcuserdata/seokkikwon.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -10,5 +10,13 @@
 			<integer>0</integer>
 		</dict>
 	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>82D4D60F2C327BDC00A92327</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/HongikYeolgong2-iOS/ContentView.swift
+++ b/HongikYeolgong2-iOS/ContentView.swift
@@ -37,7 +37,7 @@ struct ContentView: View {
             switch loginManager.signStatus {
             case .sign:
                 NavigationStack(path: $coordinator.paths) {
-                    HomeView()
+                    HomeView(viewModel: HomeViewModel())
                         .navigationDestination(for: SceneType.self) { scene in
                             coordinator.buildScreen(scene: scene)
                         }

--- a/HongikYeolgong2-iOS/Coordinator/Scene.swift
+++ b/HongikYeolgong2-iOS/Coordinator/Scene.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum SceneType: Hashable {
     case loginOnboarding
-    case home
+    case home(HomeViewModel)
     case menu
 }
 

--- a/HongikYeolgong2-iOS/Coordinator/SceneCoordinator.swift
+++ b/HongikYeolgong2-iOS/Coordinator/SceneCoordinator.swift
@@ -43,8 +43,8 @@ final class SceneCoordinator: ObservableObject {
     @ViewBuilder
     func buildScreen(scene: SceneType) -> some View {
         switch scene {
-        case .home:
-            HomeView()
+        case .home(let viewModel):
+            HomeView(viewModel: viewModel)
         case .loginOnboarding:
             LoginView()
         case .menu:

--- a/HongikYeolgong2-iOS/CustomObject/CustomButton.swift
+++ b/HongikYeolgong2-iOS/CustomObject/CustomButton.swift
@@ -31,7 +31,7 @@ struct CustomButton: View {
         Button(action: action, label: {
             Spacer()
             CustomText(font: font, title: title, textColor: titleColor, textWeight: .medium, textSize: 16)
-                .frame(width: UIScreen.UIWidth(width), height: UIScreen.UIHeight(height))
+                .frame(maxWidth: UIScreen.UIWidth(width), minHeight: UIScreen.UIHeight(height))
             Spacer()
         })        
         .background(Color(backgroundColor))

--- a/HongikYeolgong2-iOS/Extension/Date+.swift
+++ b/HongikYeolgong2-iOS/Extension/Date+.swift
@@ -1,0 +1,26 @@
+//
+//  Date+.swift
+//  HongikYeolgong2-iOS
+//
+//  Created by 석기권 on 7/11/24.
+//
+
+import Foundation
+
+extension Date {
+    func getHourMinutes() -> String {
+        let calendar = Calendar.current
+        let hour = calendar.component(.hour, from: self)
+        let minutes = calendar.component(.minute, from: self)
+        let hour12 = hour % 12 == 0 ? 12 : hour % 12
+        
+        return "\(hour12):\(minutes)"
+    }
+    
+    func getDaypart() -> String {
+        let calendar = Calendar.current
+        let hour = calendar.component(.hour, from: self)
+        let daypart = hour < 12 ? "AM" : "PM"
+        return daypart
+    }
+}

--- a/HongikYeolgong2-iOS/Extension/View+.swift
+++ b/HongikYeolgong2-iOS/Extension/View+.swift
@@ -112,3 +112,13 @@ extension View {
         modifier(DialogModifier(isPresented: isPresented, confirmAction: confirmAction, cancelAction: cancelAction))
     }
 }
+
+extension View {
+    func alert(title: String, isPresented: Binding<Bool>, confirmAction: @escaping () -> (), cancelAction: @escaping () -> ()) -> some View {
+        modifier(AlertModifier(title: title, confirmAction: confirmAction, cancleAction: cancelAction, isPresented: isPresented))
+    }
+    
+    func alert(title: String, confirmButtonText: String, cancleButtonText: String, isPresented: Binding<Bool>, confirmAction: @escaping () -> (), cancelAction: @escaping () -> ()) -> some View {
+        modifier(AlertModifier(title: title, confirmButtonText: confirmButtonText, cancleButtonText: cancleButtonText, confirmAction: confirmAction, cancleAction: cancelAction, isPresented: isPresented))
+    }
+}

--- a/HongikYeolgong2-iOS/Extension/View+.swift
+++ b/HongikYeolgong2-iOS/Extension/View+.swift
@@ -88,3 +88,27 @@ extension View {
         modifier(CustomNavBarModifier(left: left, right: right))
     }
 }
+
+extension View {
+    /// bool값에 따라 뷰의 숨김상태를 조정합니다.
+    /// - Parameter hidden: 숨김상태를 설정하는 bool 변수 입니다.
+    /// - Returns: 숨김 상태가 적용된 뷰를 반환합니다.
+    @ViewBuilder func isHidden(_ hidden: Bool) -> some View {
+            if hidden {
+                self.hidden()
+            } else {
+                self
+            }
+        }
+}
+
+extension View {
+    /// 커스텀 다이얼로그를 반환합니다.
+    /// - Parameters:
+    ///   - isPresented: 숨김 상태에 대한 변수입니다.
+    ///   - confirmAction: 확인 버튼을 터치 했을때 호출되는 클로저 입니다.
+    ///   - cancelAction: 취소 버튼을 터치 했을때 호출되는 클로저 입니다.
+    func dialog(isPresented: Binding<Bool>, confirmAction: @escaping () -> (), cancelAction: @escaping () -> ()) -> some View {
+        modifier(DialogModifier(isPresented: isPresented, confirmAction: confirmAction, cancelAction: cancelAction))
+    }
+}

--- a/HongikYeolgong2-iOS/Extension/View+.swift
+++ b/HongikYeolgong2-iOS/Extension/View+.swift
@@ -108,8 +108,8 @@ extension View {
     ///   - isPresented: 숨김 상태에 대한 변수입니다.
     ///   - confirmAction: 확인 버튼을 터치 했을때 호출되는 클로저 입니다.
     ///   - cancelAction: 취소 버튼을 터치 했을때 호출되는 클로저 입니다.
-    func dialog(isPresented: Binding<Bool>, confirmAction: @escaping () -> (), cancelAction: @escaping () -> ()) -> some View {
-        modifier(DialogModifier(isPresented: isPresented, confirmAction: confirmAction, cancelAction: cancelAction))
+    func dialog(isPresented: Binding<Bool>, currentDate: Binding<Date>, confirmAction: @escaping () -> (), cancelAction: @escaping () -> ()) -> some View {
+        modifier(DialogModifier(isPresented: isPresented, currentDate: currentDate, confirmAction: confirmAction, cancelAction: cancelAction))
     }
 }
 

--- a/HongikYeolgong2-iOS/Modifiers/AlertModifier.swift
+++ b/HongikYeolgong2-iOS/Modifiers/AlertModifier.swift
@@ -20,7 +20,7 @@ struct AlertModifier: ViewModifier {
             .overlay(
                 ZStack {
                     Color.black
-                        .opacity(0.3)
+                        .opacity(0.5)
                         .ignoresSafeArea()
                     
                     VStack(spacing: 0) {

--- a/HongikYeolgong2-iOS/Modifiers/AlertModifier.swift
+++ b/HongikYeolgong2-iOS/Modifiers/AlertModifier.swift
@@ -1,0 +1,68 @@
+//
+//  AlertModifier.swift
+//  HongikYeolgong2-iOS
+//
+//  Created by 석기권 on 7/10/24.
+//
+
+import SwiftUI
+
+struct AlertModifier: ViewModifier {
+    let title: String
+    var confirmButtonText: String = "네"
+    var cancleButtonText: String = "아니오"
+    let confirmAction: (() -> ())?
+    let cancleAction: (() -> ())?
+    
+    @Binding var isPresented: Bool
+    func body(content: Content) -> some View {
+        content
+            .overlay(
+                ZStack {
+                    Color.black
+                        .opacity(0.3)
+                        .ignoresSafeArea()
+                    
+                    VStack(spacing: 0) {
+                        Spacer().frame(height: UIScreen.UIHeight(40))
+                        
+                        // title
+                        CustomText(font: .pretendard, title: title, textColor: .customGray100, textWeight: .semibold, textSize: 18)
+                        
+                        Spacer().frame(height: UIScreen.UIHeight(30))
+                        
+                        HStack {
+                            Button(action: {
+                                cancleAction?()
+                                isPresented = false
+                            }) {
+                                CustomText(font: .pretendard, title: cancleButtonText, textColor: .customGray200, textWeight: .semibold, textSize: 16)
+                                    .frame(maxWidth: .infinity, minHeight: 46)
+                            }
+                            .background(Color(.customGray600))
+                            .cornerRadius(8)
+                            
+                            Spacer().frame(width: UIScreen.UIWidth(12))
+                            
+                            Button(action: {
+                                confirmAction?()
+                                isPresented = false
+                            }) {
+                                CustomText(font: .pretendard, title: confirmButtonText, textColor: .white, textWeight: .semibold, textSize: 16)
+                                    .frame(maxWidth: .infinity, minHeight: 46)
+                            }
+                            .background(Color(.customBlue100))
+                            .cornerRadius(8)
+                            
+                        }
+                        .padding(.horizontal, UIScreen.UIWidth(24))
+                        
+                        Spacer().frame(height: UIScreen.UIHeight(30))
+                    }
+                    .frame(maxWidth: UIScreen.UIWidth(316))
+                    .background(Color(.customGray800))
+                    .cornerRadius(8)
+                }.isHidden(!isPresented)
+            )
+    }
+}

--- a/HongikYeolgong2-iOS/Modifiers/AlertModifier.swift
+++ b/HongikYeolgong2-iOS/Modifiers/AlertModifier.swift
@@ -6,13 +6,14 @@
 //
 
 import SwiftUI
-
+import Combine
 struct AlertModifier: ViewModifier {
     let title: String
     var confirmButtonText: String = "네"
     var cancleButtonText: String = "아니오"
     let confirmAction: (() -> ())?
     let cancleAction: (() -> ())?
+    @State private var scale: CGFloat = 1
     
     @Binding var isPresented: Bool
     func body(content: Content) -> some View {
@@ -62,7 +63,19 @@ struct AlertModifier: ViewModifier {
                     .frame(maxWidth: UIScreen.UIWidth(316))
                     .background(Color(.customGray800))
                     .cornerRadius(8)
-                }.isHidden(!isPresented)
+                    .scaleEffect(scale)
+                    .animation(.interpolatingSpring(mass: 1.0, stiffness: 200, damping: 15), value: scale)
+                    }
+                    
+                    .onReceive(Just(isPresented), perform: { newValue in
+                        if newValue {
+                            scale = 1.0
+                        } else {
+                            scale = 0.9
+                        }
+                    })
+                   
+                .isHidden(!isPresented)
             )
     }
 }

--- a/HongikYeolgong2-iOS/Modifiers/DialogModifier.swift
+++ b/HongikYeolgong2-iOS/Modifiers/DialogModifier.swift
@@ -6,23 +6,27 @@
 //
 
 import SwiftUI
+import Combine
 
 struct DialogModifier: ViewModifier {
     private var hours = Array(1...12)
     private var minutes = Array(0...59)
     private var dayParts = ["AM", "PM"]
+    private var cancelablles = Set<AnyCancellable>()
     
-    @State private var selectedHour = 0
-    @State private var selectedMinute = 0
-    @State private var daypart = "AM"
+    @State private var selectedHour = CurrentValueSubject<Int, Never>(0)
+    @State private var selectedMinute = CurrentValueSubject<Int, Never>(0)
+    @State private var daypart = CurrentValueSubject<String, Never>("AM")
     
     @Binding var isPresented: Bool
+    @Binding var currentDate: Date
     
     let confirmAction: (() -> ())?
     let cancleAction: (() -> ())?
     
-    init(isPresented: Binding<Bool>, confirmAction: @escaping () -> (), cancelAction: @escaping () -> ()) {
+    init(isPresented: Binding<Bool>, currentDate: Binding<Date>, confirmAction: @escaping () -> (), cancelAction: @escaping () -> ()) {
         self._isPresented = isPresented
+        self._currentDate = currentDate
         self.confirmAction = confirmAction
         self.cancleAction = cancelAction
     }
@@ -32,7 +36,7 @@ struct DialogModifier: ViewModifier {
             .overlay (
                 ZStack {
                     Color.black
-                        .opacity(0.3)
+                        .opacity(0.5)
                         .ignoresSafeArea()
                     VStack(spacing: 0) {
                         Spacer().frame(height: UIScreen.UIHeight(40))
@@ -44,25 +48,28 @@ struct DialogModifier: ViewModifier {
                         
                         // picker
                         HStack {
-                            Picker("Hour", selection: $selectedHour) {
+                            Picker("Hour", selection: $selectedHour.value) {
                                 ForEach(hours, id: \.self) {
                                     CustomText(font: .suite, title: String(format: "%02d", $0), textColor: .white, textWeight: .bold, textSize: 24)
                                 }
+                                
+                                
                             }
                             .pickerStyle(.wheel)
                             
                             CustomText(font: .suite, title: ":", textColor: .white, textWeight: .bold, textSize: 24)
                             
-                            Picker("Minutes", selection: $selectedMinute) {
+                            Picker("Minutes", selection: $selectedMinute.value) {
                                 ForEach(minutes, id: \.self) {
                                     CustomText(font: .suite, title: String(format: "%02d", $0), textColor: .white, textWeight: .bold, textSize: 24)
                                 }
                             }
                             .pickerStyle(.wheel)
                             
-                            Picker("", selection: $daypart) {
+                            Picker("", selection: $daypart.value) {
                                 ForEach(dayParts, id: \.self) {
                                     CustomText(font: .suite, title: "\($0)", textColor: .white, textWeight: .bold, textSize: 24)
+                                    
                                 }
                             }
                             .pickerStyle(.wheel)
@@ -102,12 +109,60 @@ struct DialogModifier: ViewModifier {
                         Spacer().frame(width: UIScreen.UIHeight(30))
                         
                     }
-                        .frame(maxWidth: UIScreen.UIWidth(316), maxHeight: UIScreen.UIHeight(336))
-                        .background(Color(.customGray800))
-                        .cornerRadius(8)
-                }.isHidden(!isPresented)                  
+                    .frame(maxWidth: UIScreen.UIWidth(316), maxHeight: UIScreen.UIHeight(336))
+                    .background(Color(.customGray800))
+                    .cornerRadius(8)
+                }
+                    .isHidden(!isPresented)
+                    .onAppear {
+                        setCurrentDate()
+                    }
+                    .onReceive(Publishers.CombineLatest3(selectedHour, selectedMinute, daypart), perform: {
+                        currentDate = createDate($0.0, $0.1, $0.2) ?? Date()
+                    })
+                
             )
-           
+    }
+    
+    private func setCurrentDate() {
+        let calendar = Calendar.current
+        
+        let hour = calendar.component(.hour, from: currentDate)
+        let minutes = calendar.component(.minute, from: currentDate)
+        let hour12 = hour % 12 == 0 ? 12 : hour % 12
+        let period = hour < 12 ? "AM" : "PM"
+        
+        selectedHour.send(hour12)
+        selectedMinute.send(minutes)
+        daypart.send(period)
+    }
+    
+    
+    func createDate(_ hour: Int, _ minute: Int, _ period: String) -> Date? {
+        var adjustedHour = hour
+        
+        if period.uppercased() == "PM" && hour != 12 {
+            adjustedHour += 12
+        }
+        
+        if period.uppercased() == "AM" && hour == 12 {
+            adjustedHour = 0
+        }
+        
+        let now = Date()
+        let calendar = Calendar.current
+        let year = calendar.component(.year, from: now)
+        let month = calendar.component(.month, from: now)
+        let day = calendar.component(.day, from: now)
+        
+        var dateComponents = DateComponents()
+        dateComponents.year = year
+        dateComponents.month = month
+        dateComponents.day = day
+        dateComponents.hour = adjustedHour
+        dateComponents.minute = minute
+        
+        return calendar.date(from: dateComponents)
     }
 }
 

--- a/HongikYeolgong2-iOS/Modifiers/DialogModifier.swift
+++ b/HongikYeolgong2-iOS/Modifiers/DialogModifier.swift
@@ -1,0 +1,20 @@
+//
+//  DialogModifier.swift
+//  HongikYeolgong2-iOS
+//
+//  Created by 석기권 on 7/10/24.
+//
+
+import SwiftUI
+
+struct DialogModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        ZStack {
+            
+            content
+        }
+        .background(.red)
+    }
+}
+
+

--- a/HongikYeolgong2-iOS/Modifiers/DialogModifier.swift
+++ b/HongikYeolgong2-iOS/Modifiers/DialogModifier.swift
@@ -35,12 +35,12 @@ struct DialogModifier: ViewModifier {
                         .opacity(0.3)
                         .ignoresSafeArea()
                     VStack(spacing: 0) {
-                        Spacer().frame(width: UIScreen.UIHeight(40))
+                        Spacer().frame(height: UIScreen.UIHeight(40))
                         
                         // title
                         CustomText(font: .pretendard, title: "열람실 이용 시작 시간", textColor: .customGray100, textWeight: .semibold, textSize: 18)
                         
-                        Spacer().frame(width: UIScreen.UIHeight(30))
+                        Spacer().frame(height: UIScreen.UIHeight(30))
                         
                         // picker
                         HStack {
@@ -70,7 +70,7 @@ struct DialogModifier: ViewModifier {
                         .frame(height: UIScreen.UIHeight(126))
                         .padding(.horizontal, UIScreen.UIWidth(50))
                         
-                        Spacer().frame(width: UIScreen.UIHeight(32))
+                        Spacer().frame(height: UIScreen.UIHeight(32))
                         
                         // button
                         HStack {
@@ -105,7 +105,7 @@ struct DialogModifier: ViewModifier {
                         .frame(maxWidth: UIScreen.UIWidth(316), maxHeight: UIScreen.UIHeight(336))
                         .background(Color(.customGray800))
                         .cornerRadius(8)
-                }.isHidden(!isPresented)                   
+                }.isHidden(!isPresented)                  
             )
            
     }

--- a/HongikYeolgong2-iOS/Modifiers/DialogModifier.swift
+++ b/HongikYeolgong2-iOS/Modifiers/DialogModifier.swift
@@ -8,12 +8,106 @@
 import SwiftUI
 
 struct DialogModifier: ViewModifier {
+    private var hours = Array(1...12)
+    private var minutes = Array(0...59)
+    private var dayParts = ["AM", "PM"]
+    
+    @State private var selectedHour = 0
+    @State private var selectedMinute = 0
+    @State private var daypart = "AM"
+    
+    @Binding var isPresented: Bool
+    
+    let confirmAction: (() -> ())?
+    let cancleAction: (() -> ())?
+    
+    init(isPresented: Binding<Bool>, confirmAction: @escaping () -> (), cancelAction: @escaping () -> ()) {
+        self._isPresented = isPresented
+        self.confirmAction = confirmAction
+        self.cancleAction = cancelAction
+    }
+    
     func body(content: Content) -> some View {
-        ZStack {
-            
-            content
-        }
-        .background(.red)
+        content
+            .overlay (
+                ZStack {
+                    Color.black
+                        .opacity(0.3)
+                        .ignoresSafeArea()
+                    VStack(spacing: 0) {
+                        Spacer().frame(width: UIScreen.UIHeight(40))
+                        
+                        // title
+                        CustomText(font: .pretendard, title: "열람실 이용 시작 시간", textColor: .customGray100, textWeight: .semibold, textSize: 18)
+                        
+                        Spacer().frame(width: UIScreen.UIHeight(30))
+                        
+                        // picker
+                        HStack {
+                            Picker("Hour", selection: $selectedHour) {
+                                ForEach(hours, id: \.self) {
+                                    CustomText(font: .suite, title: String(format: "%02d", $0), textColor: .white, textWeight: .bold, textSize: 24)
+                                }
+                            }
+                            .pickerStyle(.wheel)
+                            
+                            CustomText(font: .suite, title: ":", textColor: .white, textWeight: .bold, textSize: 24)
+                            
+                            Picker("Minutes", selection: $selectedMinute) {
+                                ForEach(minutes, id: \.self) {
+                                    CustomText(font: .suite, title: String(format: "%02d", $0), textColor: .white, textWeight: .bold, textSize: 24)
+                                }
+                            }
+                            .pickerStyle(.wheel)
+                            
+                            Picker("", selection: $daypart) {
+                                ForEach(dayParts, id: \.self) {
+                                    CustomText(font: .suite, title: "\($0)", textColor: .white, textWeight: .bold, textSize: 24)
+                                }
+                            }
+                            .pickerStyle(.wheel)
+                        }
+                        .frame(height: UIScreen.UIHeight(126))
+                        .padding(.horizontal, UIScreen.UIWidth(50))
+                        
+                        Spacer().frame(width: UIScreen.UIHeight(32))
+                        
+                        // button
+                        HStack {
+                            Button(action: {
+                                cancleAction?()
+                                isPresented = false
+                            }) {
+                                CustomText(font: .pretendard, title: "취소", textColor: .customGray200, textWeight: .semibold, textSize: 16)
+                                    .frame(maxWidth: .infinity, minHeight: 46)
+                            }
+                            .background(Color(.customGray600))
+                            .cornerRadius(8)
+                            
+                            Spacer().frame(width: UIScreen.UIWidth(12))
+                            
+                            Button(action: {
+                                confirmAction?()
+                                isPresented = false
+                            }) {
+                                CustomText(font: .pretendard, title: "확인", textColor: .white, textWeight: .semibold, textSize: 16)
+                                    .frame(maxWidth: .infinity, minHeight: 46)
+                            }
+                            .background(Color(.customBlue100))
+                            .cornerRadius(8)
+                            
+                        }
+                        .padding(.horizontal, UIScreen.UIWidth(24))
+                        
+                        Spacer().frame(width: UIScreen.UIHeight(30))
+                        
+                    }
+                        .frame(maxWidth: UIScreen.UIWidth(316), maxHeight: UIScreen.UIHeight(336))
+                        .background(Color(.customGray800))
+                        .cornerRadius(8)
+                }.isHidden(!isPresented)                   
+            )
+           
     }
 }
 

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -12,6 +12,9 @@ struct HomeView: View {
     @State private var isStart = false
     @State private var showingDialog = false
     @State private var showingAlert = false
+    @State private var showingAlert2 = false
+    @State private var currentDate = Date()
+    
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
@@ -28,9 +31,14 @@ struct HomeView: View {
             
             if isStart {
                 CustomButton(action: {
+                    showingAlert2 = true
+                }, font: .suite, title: "열람실 이용 연장", titleColor: .customGray100, backgroundColor: .customBlue100, leading: 0, trailing: 0)
+                
+                Spacer().frame(height: UIScreen.UIHeight(12))
+                
+                CustomButton(action: {
                     showingAlert = true
                 }, font: .suite, title: "열람실 이용 종료", titleColor: .customGray100, backgroundColor: .customGray600, leading: 0, trailing: 0)
-                
             } else {
                 HStack {
                     CustomButton2(action: {}, title: "좌석", image: .angularButton01, maxWidth: 69, minHeight: 52)
@@ -56,6 +64,7 @@ struct HomeView: View {
             })
         })
         .dialog(isPresented: $showingDialog,
+                currentDate: $currentDate,
                 confirmAction: {
             isStart = true
             print("확인버튼 눌림")
@@ -66,7 +75,11 @@ struct HomeView: View {
         }, cancelAction: {
             
         })
-        
+        .alert(title: "열람실 이용 시간을 연장할까요?", confirmButtonText: "연장하기", cancleButtonText: "아니오", isPresented: $showingAlert2, confirmAction: {
+   
+        }, cancelAction: {
+            
+        })
     }
 }
 

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -12,7 +12,6 @@ struct HomeView: View {
     @State private var isStart = false
     
     var body: some View {
-        
         VStack(spacing: 0) {
             Spacer()
                 .frame(height: isStart ? UIScreen.UIHeight(11) : UIScreen.UIHeight(43))
@@ -55,6 +54,8 @@ struct HomeView: View {
                 Image(.icHamburger)
             })
         })
+        .modifier(DialogModifier())
+        
     }
 }
 

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct HomeView: View {
     @EnvironmentObject private var coordinator: SceneCoordinator
     @State private var isStart = false
+    @State private var isPresented = false
     
     var body: some View {
         VStack(spacing: 0) {
@@ -37,7 +38,7 @@ struct HomeView: View {
                     Spacer(minLength: 12)
                     
                     CustomButton2(action: {
-                        isStart = true
+                        isPresented = true
                     }, title: "열람실 이용 시작", image: .angularButton02, maxWidth: .infinity, minHeight: 52)
                 }
                 
@@ -54,7 +55,12 @@ struct HomeView: View {
                 Image(.icHamburger)
             })
         })
-        .modifier(DialogModifier())
+        .dialog(isPresented: $isPresented,
+                confirmAction: {
+            isStart = true
+            print("확인버튼 눌림")
+        }, cancelAction: {
+        })
         
     }
 }

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -9,37 +9,32 @@ import SwiftUI
 
 struct HomeView: View {
     @EnvironmentObject private var coordinator: SceneCoordinator
-    @State private var isStart = false
-    @State private var showingDialog = false
-    @State private var showingAlert = false
-    @State private var showingAlert2 = false
-    @State private var currentDate = Date()
     
-    let viewModel: HomeViewModel!
+    @StateObject var viewModel: HomeViewModel
     
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
-                .frame(height: isStart ? UIScreen.UIHeight(11) : UIScreen.UIHeight(43))
+                .frame(height: viewModel.isRoomReserved ? UIScreen.UIHeight(11) : UIScreen.UIHeight(43))
             
-            if isStart {
-                TimeLapse()
+            if viewModel.isRoomReserved {
+                TimeLapse(startTime: viewModel.useageStartTime, endTime: viewModel.useageStartTime + TimeInterval(3600 * 4))
             } else {
                 Quote()
             }
             
             Spacer()
-                .frame(height: isStart ? UIScreen.UIHeight(28) : UIScreen.UIHeight(120))
+                .frame(height: viewModel.isRoomReserved ? UIScreen.UIHeight(28) : UIScreen.UIHeight(120))
             
-            if isStart {
+            if viewModel.isRoomReserved {
                 CustomButton(action: {
-                    showingAlert2 = true
+                    viewModel.showingAlert2 = true
                 }, font: .suite, title: "열람실 이용 연장", titleColor: .customGray100, backgroundColor: .customBlue100, leading: 0, trailing: 0)
                 
                 Spacer().frame(height: UIScreen.UIHeight(12))
                 
                 CustomButton(action: {
-                    showingAlert = true
+                    viewModel.showingAlert = true
                 }, font: .suite, title: "열람실 이용 종료", titleColor: .customGray100, backgroundColor: .customGray600, leading: 0, trailing: 0)
             } else {
                 HStack {
@@ -48,7 +43,7 @@ struct HomeView: View {
                     Spacer(minLength: 12)
                     
                     CustomButton2(action: {
-                        showingDialog = true
+                        viewModel.showingDialog = true
                     }, title: "열람실 이용 시작", image: .angularButton02, maxWidth: .infinity, minHeight: 52)
                 }
                 
@@ -65,20 +60,20 @@ struct HomeView: View {
                 Image(.icHamburger)
             })
         })
-        .dialog(isPresented: $showingDialog,
-                currentDate: $currentDate,
+        .dialog(isPresented: $viewModel.showingDialog,
+                currentDate: $viewModel.useageStartTime,
                 confirmAction: {
-            isStart = true
+            viewModel.startRoomUsage()
             print("확인버튼 눌림")
         }, cancelAction: {
         })
-        .alert(title: "열람실을 다 이용하셨나요?", confirmButtonText: "네", cancleButtonText: "더 이용하기", isPresented: $showingAlert, confirmAction: {
-            isStart = false
+        .alert(title: "열람실을 다 이용하셨나요?", confirmButtonText: "네", cancleButtonText: "더 이용하기", isPresented: $viewModel.showingAlert, confirmAction: {
+            viewModel.cancleRoomUsage()
         }, cancelAction: {
             
         })
-        .alert(title: "열람실 이용 시간을 연장할까요?", confirmButtonText: "연장하기", cancleButtonText: "아니오", isPresented: $showingAlert2, confirmAction: {
-   
+        .alert(title: "열람실 이용 시간을 연장할까요?", confirmButtonText: "연장하기", cancleButtonText: "아니오", isPresented: $viewModel.showingAlert2, confirmAction: {
+            
         }, cancelAction: {
             
         })

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -15,6 +15,8 @@ struct HomeView: View {
     @State private var showingAlert2 = false
     @State private var currentDate = Date()
     
+    let viewModel: HomeViewModel!
+    
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
@@ -85,5 +87,5 @@ struct HomeView: View {
 
 
 #Preview {
-    HomeView()
+    HomeView(viewModel: HomeViewModel())
 }

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 struct HomeView: View {
     @EnvironmentObject private var coordinator: SceneCoordinator
     @State private var isStart = false
-    @State private var isPresented = false
-    
+    @State private var showingDialog = false
+    @State private var showingAlert = false
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
@@ -28,7 +28,7 @@ struct HomeView: View {
             
             if isStart {
                 CustomButton(action: {
-                    isStart = false
+                    showingAlert = true
                 }, font: .suite, title: "열람실 이용 종료", titleColor: .customGray100, backgroundColor: .customGray600, leading: 0, trailing: 0)
                 
             } else {
@@ -38,7 +38,7 @@ struct HomeView: View {
                     Spacer(minLength: 12)
                     
                     CustomButton2(action: {
-                        isPresented = true
+                        showingDialog = true
                     }, title: "열람실 이용 시작", image: .angularButton02, maxWidth: .infinity, minHeight: 52)
                 }
                 
@@ -55,11 +55,16 @@ struct HomeView: View {
                 Image(.icHamburger)
             })
         })
-        .dialog(isPresented: $isPresented,
+        .dialog(isPresented: $showingDialog,
                 confirmAction: {
             isStart = true
             print("확인버튼 눌림")
         }, cancelAction: {
+        })
+        .alert(title: "열람실을 다 이용하셨나요?", confirmButtonText: "네", cancleButtonText: "더 이용하기", isPresented: $showingAlert, confirmAction: {
+            isStart = false
+        }, cancelAction: {
+            
         })
         
     }

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeViewModel.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeViewModel.swift
@@ -7,4 +7,18 @@
 
 import Foundation
 
-final class HomeViewModel: ObservableObject {}
+final class HomeViewModel: ObservableObject {
+    @Published var isRoomReserved = false
+    @Published var useageStartTime = Date()
+    @Published var showingAlert = false
+    @Published var showingAlert2 = false
+    @Published var showingDialog = false
+    
+    func startRoomUsage() {
+        isRoomReserved = true
+    }
+    
+    func cancleRoomUsage() {
+        isRoomReserved = false
+    }
+}

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeViewModel.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeViewModel.swift
@@ -1,0 +1,10 @@
+//
+//  HomeViewModel.swift
+//  HongikYeolgong2-iOS
+//
+//  Created by 석기권 on 7/11/24.
+//
+
+import Foundation
+
+final class HomeViewModel: ObservableObject {}

--- a/HongikYeolgong2-iOS/Scene/Container/Ready/TimeLapse.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Ready/TimeLapse.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 
 struct TimeLapse: View {
+    let startTime: Date
+    let endTime: Date
+    
     var body: some View {
         VStack(spacing: 0) {
             HStack {
@@ -25,16 +28,16 @@ struct TimeLapse: View {
             // 이용 시간
             HStack {
                 HStack {
-                    CustomText(font: .suite, title: "11:30", textColor: .customGray100, textWeight: .extrabold, textSize: 30)
-                    CustomText(font: .suite, title: "AM", textColor: .customGray100, textWeight: .medium, textSize: 14)
+                    CustomText(font: .suite, title: startTime.getHourMinutes(), textColor: .customGray100, textWeight: .extrabold, textSize: 30)
+                    CustomText(font: .suite, title: startTime.getDaypart(), textColor: .customGray100, textWeight: .medium, textSize: 14)
                 }
                 
                 Spacer()
                     .frame(width: UIScreen.UIWidth(53))
                 
                 HStack {
-                    CustomText(font: .suite, title: "5:30", textColor: .customGray100, textWeight: .extrabold, textSize: 30)
-                    CustomText(font: .suite, title: "PM", textColor: .customGray100, textWeight: .medium, textSize: 14)
+                    CustomText(font: .suite, title: endTime.getHourMinutes(), textColor: .customGray100, textWeight: .extrabold, textSize: 30)
+                    CustomText(font: .suite, title: endTime.getDaypart(), textColor: .customGray100, textWeight: .medium, textSize: 14)
                 }
                 Spacer()
             }
@@ -67,5 +70,5 @@ struct TimeLapse: View {
 }
 
 #Preview {
-    TimeLapse()
+    TimeLapse(startTime: Date(), endTime: Date())
 }


### PR DESCRIPTION
## AS-IS
앱전체 여러곳에서 사용되는 Dialog를 각각 만든다면 코드의 양이 불필요하게 늘어나며 디자인의 일관성을 유지하기 어렵고 수정시에 많은 비용이  들게됩니다.
## TO-BE
Dialog 컴포넌트를 공통 컴포넌트로 만들어서 앱전체에서 컴포넌트를 호출하여 사용할 수 있도록 했습니다. Dialog 컴포넌트만 관리하면 되기떄문에 디자인의 일관성이 유지되며 수정시에도 Dialog 컴포넌트만 수정하면 됩니다.
## KEY-POINT
커스텀 네비게이션과 동일하게 구현체와 modifier를 호출하는 extension 메서드로 구현되어 있습니다.

```swift
extension View {
    func alert(title: String, isPresented: Binding<Bool>, confirmAction: @escaping () -> (), cancelAction: @escaping () -> ()) -> some View {
        modifier(AlertModifier(title: title, confirmAction: confirmAction, cancleAction: cancelAction, isPresented: isPresented))
    }
    
    func alert(title: String, confirmButtonText: String, cancleButtonText: String, isPresented: Binding<Bool>, confirmAction: @escaping () -> (), cancelAction: @escaping () -> ()) -> some View {
        modifier(AlertModifier(title: title, confirmButtonText: confirmButtonText, cancleButtonText: cancleButtonText, confirmAction: confirmAction, cancleAction: cancelAction, isPresented: isPresented))
    }
}
```
AlertModifier가 적용된 View를 반환하는 메서드를 호출합니다. alert의 confirmButton과 cancleButton의 텍스트가 각각 다르기 때문에 호출하는 곳에서 직접 설정할 수 있도록 하였습니다.

```swift
 .alert(title: "열람실을 다 이용하셨나요?", confirmButtonText: "네", cancleButtonText: "더 이용하기", isPresented: $viewModel.showingAlert, confirmAction: {
            viewModel.cancleRoomUsage()
        }, cancelAction: {
            
        })
```
실제 사용하는 곳에서는 .alert 또는 .dialog로 호출하면 사용이 가능합니다.


## SCREENSHOT (Optional)

https://github.com/TeamHY2/HongikYeolgong2-iOS/assets/101062450/cdadcb77-dd8e-45c8-887c-0050a651f480

