### PR TITLE
[Feature] 홈화면에 필요한 커스텀캘린더 컴포넌트를 구현합니다.

### DIFF
--- a/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		5E89D79A2C35855F00C9CB71 /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E89D7992C35855F00C9CB71 /* Font+.swift */; };
 		8252CCDC2C40396100690D75 /* Calendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8252CCDB2C40396100690D75 /* Calendar.swift */; };
 		8252CCDE2C40440600690D75 /* CalendarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8252CCDD2C40440600690D75 /* CalendarCell.swift */; };
+		8252CCE02C404A7300690D75 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8252CCDF2C404A7300690D75 /* Day.swift */; };
 		825665792C35202E0018C799 /* MenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825665782C35202E0018C799 /* MenuViewModel.swift */; };
 		825668A52C367ED30066B216 /* CustomNavBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825668A42C367ED30066B216 /* CustomNavBarModifier.swift */; };
 		825668A72C367F130066B216 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825668A62C367F130066B216 /* View+.swift */; };
@@ -62,6 +63,7 @@
 		5E89D7992C35855F00C9CB71 /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
 		8252CCDB2C40396100690D75 /* Calendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar.swift; sourceTree = "<group>"; };
 		8252CCDD2C40440600690D75 /* CalendarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCell.swift; sourceTree = "<group>"; };
+		8252CCDF2C404A7300690D75 /* Day.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Day.swift; sourceTree = "<group>"; };
 		825665782C35202E0018C799 /* MenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewModel.swift; sourceTree = "<group>"; };
 		825668A42C367ED30066B216 /* CustomNavBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavBarModifier.swift; sourceTree = "<group>"; };
 		825668A62C367F130066B216 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 		5E5B0BC42C32866900936435 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				8252CCDF2C404A7300690D75 /* Day.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -392,6 +395,7 @@
 				8274CF392C33DB1000FBFA9D /* HomeView.swift in Sources */,
 				82D4D6162C327BDC00A92327 /* ContentView.swift in Sources */,
 				8252CCDC2C40396100690D75 /* Calendar.swift in Sources */,
+				8252CCE02C404A7300690D75 /* Day.swift in Sources */,
 				82B1FE7B2C3BC567002D9163 /* Quote.swift in Sources */,
 				82AB4F212C3EE9DB00787B3B /* HomeViewModel.swift in Sources */,
 				8274CF372C33D6D600FBFA9D /* SceneCoordinatorType.swift in Sources */,

--- a/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		5E5CD43F2C3698A4002CE244 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5CD43E2C3698A4002CE244 /* CustomButton.swift */; };
 		5E5CD4412C369994002CE244 /* UIScreen+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5CD4402C369994002CE244 /* UIScreen+.swift */; };
 		5E89D79A2C35855F00C9CB71 /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E89D7992C35855F00C9CB71 /* Font+.swift */; };
+		8252CCDC2C40396100690D75 /* Calendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8252CCDB2C40396100690D75 /* Calendar.swift */; };
+		8252CCDE2C40440600690D75 /* CalendarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8252CCDD2C40440600690D75 /* CalendarCell.swift */; };
 		825665792C35202E0018C799 /* MenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825665782C35202E0018C799 /* MenuViewModel.swift */; };
 		825668A52C367ED30066B216 /* CustomNavBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825668A42C367ED30066B216 /* CustomNavBarModifier.swift */; };
 		825668A72C367F130066B216 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825668A62C367F130066B216 /* View+.swift */; };
@@ -58,6 +60,8 @@
 		5E5CD4402C369994002CE244 /* UIScreen+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+.swift"; sourceTree = "<group>"; };
 		5E89D7712C356E5500C9CB71 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		5E89D7992C35855F00C9CB71 /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
+		8252CCDB2C40396100690D75 /* Calendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar.swift; sourceTree = "<group>"; };
+		8252CCDD2C40440600690D75 /* CalendarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCell.swift; sourceTree = "<group>"; };
 		825665782C35202E0018C799 /* MenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewModel.swift; sourceTree = "<group>"; };
 		825668A42C367ED30066B216 /* CustomNavBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavBarModifier.swift; sourceTree = "<group>"; };
 		825668A62C367F130066B216 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
@@ -228,6 +232,8 @@
 		825665772C351B5A0018C799 /* Calendar */ = {
 			isa = PBXGroup;
 			children = (
+				8252CCDB2C40396100690D75 /* Calendar.swift */,
+				8252CCDD2C40440600690D75 /* CalendarCell.swift */,
 			);
 			path = Calendar;
 			sourceTree = "<group>";
@@ -385,12 +391,14 @@
 				825668A92C36855A0066B216 /* UINavigationController+.swift in Sources */,
 				8274CF392C33DB1000FBFA9D /* HomeView.swift in Sources */,
 				82D4D6162C327BDC00A92327 /* ContentView.swift in Sources */,
+				8252CCDC2C40396100690D75 /* Calendar.swift in Sources */,
 				82B1FE7B2C3BC567002D9163 /* Quote.swift in Sources */,
 				82AB4F212C3EE9DB00787B3B /* HomeViewModel.swift in Sources */,
 				8274CF372C33D6D600FBFA9D /* SceneCoordinatorType.swift in Sources */,
 				825668A52C367ED30066B216 /* CustomNavBarModifier.swift in Sources */,
 				825668A72C367F130066B216 /* View+.swift in Sources */,
 				825665792C35202E0018C799 /* MenuViewModel.swift in Sources */,
+				8252CCDE2C40440600690D75 /* CalendarCell.swift in Sources */,
 				5E89D79A2C35855F00C9CB71 /* Font+.swift in Sources */,
 				82B1FE812C3C1755002D9163 /* CustomButton2.swift in Sources */,
 				5E5B0BD32C3289D500936435 /* UIColor+.swift in Sources */,

--- a/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		8252CCDC2C40396100690D75 /* Calendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8252CCDB2C40396100690D75 /* Calendar.swift */; };
 		8252CCDE2C40440600690D75 /* CalendarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8252CCDD2C40440600690D75 /* CalendarCell.swift */; };
 		8252CCE02C404A7300690D75 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8252CCDF2C404A7300690D75 /* Day.swift */; };
+		8252CCE22C404CFE00690D75 /* CalendarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8252CCE12C404CFE00690D75 /* CalendarManager.swift */; };
 		825665792C35202E0018C799 /* MenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825665782C35202E0018C799 /* MenuViewModel.swift */; };
 		825668A52C367ED30066B216 /* CustomNavBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825668A42C367ED30066B216 /* CustomNavBarModifier.swift */; };
 		825668A72C367F130066B216 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825668A62C367F130066B216 /* View+.swift */; };
@@ -64,6 +65,7 @@
 		8252CCDB2C40396100690D75 /* Calendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar.swift; sourceTree = "<group>"; };
 		8252CCDD2C40440600690D75 /* CalendarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCell.swift; sourceTree = "<group>"; };
 		8252CCDF2C404A7300690D75 /* Day.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Day.swift; sourceTree = "<group>"; };
+		8252CCE12C404CFE00690D75 /* CalendarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarManager.swift; sourceTree = "<group>"; };
 		825665782C35202E0018C799 /* MenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewModel.swift; sourceTree = "<group>"; };
 		825668A42C367ED30066B216 /* CustomNavBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavBarModifier.swift; sourceTree = "<group>"; };
 		825668A62C367F130066B216 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
@@ -237,6 +239,7 @@
 			children = (
 				8252CCDB2C40396100690D75 /* Calendar.swift */,
 				8252CCDD2C40440600690D75 /* CalendarCell.swift */,
+				8252CCE12C404CFE00690D75 /* CalendarManager.swift */,
 			);
 			path = Calendar;
 			sourceTree = "<group>";
@@ -407,6 +410,7 @@
 				82B1FE812C3C1755002D9163 /* CustomButton2.swift in Sources */,
 				5E5B0BD32C3289D500936435 /* UIColor+.swift in Sources */,
 				8274CF332C33D59400FBFA9D /* Scene.swift in Sources */,
+				8252CCE22C404CFE00690D75 /* CalendarManager.swift in Sources */,
 				82D4D6142C327BDC00A92327 /* HongikYeolgong2_iOSApp.swift in Sources */,
 				82AB4F232C3EEE6D00787B3B /* Date+.swift in Sources */,
 				5E5CD4412C369994002CE244 /* UIScreen+.swift in Sources */,

--- a/HongikYeolgong2-iOS/Extension/Date+.swift
+++ b/HongikYeolgong2-iOS/Extension/Date+.swift
@@ -23,4 +23,16 @@ extension Date {
         let daypart = hour < 12 ? "AM" : "PM"
         return daypart
     }
+    
+    func getMonthString() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "LLL"
+        return dateFormatter.string(from: self)
+    }
+    
+    func getYearString() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy"
+        return dateFormatter.string(from: self)
+    }
 }

--- a/HongikYeolgong2-iOS/Model/Day.swift
+++ b/HongikYeolgong2-iOS/Model/Day.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
-struct Day {
+struct Day: Identifiable {
+    var id = UUID().uuidString
+    
     let dayOfNumber: String
 }

--- a/HongikYeolgong2-iOS/Model/Day.swift
+++ b/HongikYeolgong2-iOS/Model/Day.swift
@@ -1,0 +1,12 @@
+//
+//  Day.swift
+//  HongikYeolgong2-iOS
+//
+//  Created by 석기권 on 7/12/24.
+//
+
+import Foundation
+
+struct Day {
+    let dayOfNumber: String
+}

--- a/HongikYeolgong2-iOS/Scene/Container/Calendar/Calendar.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Calendar/Calendar.swift
@@ -1,0 +1,74 @@
+//
+//  Calendar.swift
+//  HongikYeolgong2-iOS
+//
+//  Created by 석기권 on 7/12/24.
+//
+
+import SwiftUI
+
+enum WeekDay: String, CaseIterable {
+    case sun = "Sun"
+    case Mon = "Mon"
+    case Tue = "Tue"
+    case Wed = "Wed"
+    case Thu = "Thu"
+    case Fri = "Fri"
+    case Sat = "Sat"
+}
+
+struct CalendarView: View {
+    
+    private let columns = [GridItem(.flexible()),
+                           GridItem(.flexible()),
+                           GridItem(.flexible()),
+                           GridItem(.flexible()),
+                           GridItem(.flexible()),
+                           GridItem(.flexible()),
+                           GridItem(.flexible())]
+    private let days = Array(1...42).map { String($0) }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            // header
+            HStack(spacing: 0) {
+                CustomText(font: .suite, title: "Jan 2024", textColor: .customGray100, textWeight: .bold, textSize: 24)
+                Spacer()
+                HStack {
+                    Button(action: {}) {
+                        Image(.icCalendarLeft)
+                    }
+                    
+                    Spacer().frame(width: UIScreen.UIWidth(7))
+                    
+                    Button(action: {}) {
+                        Image(.icCalendarRight)
+                    }
+                }
+            }
+            
+            Spacer().frame(height: UIScreen.UIHeight(12))
+            
+            // weakday
+            HStack(alignment: .center) {
+                ForEach(WeekDay.allCases, id: \.rawValue) {
+                    CustomText(font: .suite, title: $0.rawValue, textColor: .customGray300, textWeight: .medium, textSize: 12)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            
+            Spacer().frame(height: UIScreen.UIHeight(8))
+            
+            // grid
+            LazyVGrid(columns: columns, spacing: UIScreen.UIWidth(5)) {
+                ForEach(days, id: \.self) {
+                    CalendarCell(dayOfNumber: $0)                        
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    CalendarView()
+}

--- a/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarCell.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarCell.swift
@@ -18,6 +18,7 @@ struct CalendarCell: View {
         .frame(height: UIScreen.UIHeight(33))
         .background(Color(.customGray800))
         .cornerRadius(8)
+        .opacity(dayOfNumber.isEmpty ? 0 : 1)
     }
 }
 

--- a/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarCell.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarCell.swift
@@ -1,0 +1,26 @@
+//
+//  CalendarCell.swift
+//  HongikYeolgong2-iOS
+//
+//  Created by 석기권 on 7/12/24.
+//
+
+import SwiftUI
+
+struct CalendarCell: View {
+    let dayOfNumber: String
+    
+    var body: some View {
+        VStack {
+            CustomText(font: .suite, title: dayOfNumber, textColor: .customGray300, textWeight: .medium, textSize: 14)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: UIScreen.UIHeight(33))
+        .background(Color(.customGray800))
+        .cornerRadius(8)
+    }
+}
+
+#Preview {
+    CalendarCell(dayOfNumber: "1")
+}

--- a/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarCell.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarCell.swift
@@ -7,18 +7,59 @@
 
 import SwiftUI
 
+enum CellStyle: CaseIterable {
+    case dayCount00
+    case dayCount01
+    case dayCount02
+    case dayCount03
+}
+
 struct CalendarCell: View {
     let dayOfNumber: String
+    let cellStyle: CellStyle = CellStyle.allCases.randomElement()!
     
     var body: some View {
-        VStack {
-            CustomText(font: .suite, title: dayOfNumber, textColor: .customGray300, textWeight: .medium, textSize: 14)
+        
+        switch cellStyle {
+        case .dayCount00:
+            VStack {
+                CustomText(font: .suite, title: dayOfNumber, textColor: .customGray300, textWeight: .medium, textSize: 14)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: UIScreen.UIHeight(33))
+            .background(Color(.customGray800))
+            .cornerRadius(8)
+            .opacity(dayOfNumber.isEmpty ? 0 : 1)
+        case .dayCount01:
+            VStack {
+                CustomText(font: .suite, title: dayOfNumber, textColor: .customGray100, textWeight: .medium, textSize: 14)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: UIScreen.UIHeight(33))
+            .background(Image(.dayCount01))
+            .cornerRadius(8)
+            .opacity(dayOfNumber.isEmpty ? 0 : 1)
+        case .dayCount02:
+            VStack {
+                CustomText(font: .suite, title: dayOfNumber, textColor: .white, textWeight: .medium, textSize: 14)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: UIScreen.UIHeight(33))
+            .background(Image(.dayCount02))
+            .cornerRadius(8)
+            .opacity(dayOfNumber.isEmpty ? 0 : 1)
+        case .dayCount03:
+            VStack {
+                CustomText(font: .suite, title: dayOfNumber, textColor: .customGray600, textWeight: .medium, textSize: 14)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: UIScreen.UIHeight(33))
+            .background(Image(.dayCount03))
+            .cornerRadius(8)
+            .opacity(dayOfNumber.isEmpty ? 0 : 1)
         }
-        .frame(maxWidth: .infinity)
-        .frame(height: UIScreen.UIHeight(33))
-        .background(Color(.customGray800))
-        .cornerRadius(8)
-        .opacity(dayOfNumber.isEmpty ? 0 : 1)
+        
+        
     }
 }
 

--- a/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarManager.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarManager.swift
@@ -1,0 +1,72 @@
+//
+//  CalendarManager.swift
+//  HongikYeolgong2-iOS
+//
+//  Created by 석기권 on 7/12/24.
+//
+
+import Foundation
+import Combine
+
+final class CalendarManager {
+    static let shared = CalendarManager()
+    
+    private init() {}
+    
+    let calendar = Calendar.current
+    
+    func plusMonth(date: Date) -> Date {
+        return calendar.date(byAdding: .month, value: 1, to: date)!
+    }
+    
+    func minusMonth(date: Date) -> Date {
+        return calendar.date(byAdding: .month, value: -1, to: date)!
+    }
+    
+    func daysInMonth(date: Date) -> Int {
+        let range = calendar.range(of: .day, in: .month, for: date)!
+        return range.count
+    }
+    
+    /// 현재 날짜
+    func daysOfMonth(date: Date) -> Int {
+        let componets = calendar.dateComponents([.day], from: date)
+        return componets.day!
+    }
+    
+    /// 현재 달의 첫번째 날에대한 정보
+    func firstOfMonth(date: Date) -> Date {
+        
+        let components = calendar.dateComponents([.year, .month], from: date)
+        return calendar.date(from: components)!
+    }
+    
+    func weekDay(date: Date) -> Int {
+        let components = calendar.dateComponents([.weekday], from: date)
+        return components.weekday! - 1
+    }
+    
+    func makeMonth(date: Date) -> AnyPublisher<[Day], Never> {
+        let daysInMonth = daysInMonth(date: date)
+        let firstDayOfMonth = firstOfMonth(date: date)
+        let startingSpace = weekDay(date: firstDayOfMonth)
+        
+        var count: Int = 1
+        var days: [Day] = []
+        
+        while(count <= 42) {
+            if (count <= startingSpace || count - startingSpace > daysInMonth) {
+                days.append(Day(dayOfNumber: ""))
+            }
+            else {
+                let numberOfDay = count - startingSpace
+                guard calendar.date(byAdding: .day, value: numberOfDay - 1, to: firstOfMonth(date: date)) != nil else {
+                    return Just([]).eraseToAnyPublisher()
+                }
+                days.append(Day(dayOfNumber: "\(count - startingSpace)"))
+            }
+            count += 1
+        }
+        return Just(days).eraseToAnyPublisher()
+    }
+}

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -50,6 +50,8 @@ struct HomeView: View {
             }
             
             Spacer()
+            
+            CalendarView()
         }
         .customNavigation(left: {
             CustomText(font: .suite, title: "홍익열공이", textColor: .customGray100, textWeight: .semibold, textSize: 18)

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -40,7 +40,7 @@ struct HomeView: View {
                 HStack {
                     CustomButton2(action: {}, title: "좌석", image: .angularButton01, maxWidth: 69, minHeight: 52)
                     
-                    Spacer(minLength: 12)
+                    Spacer().frame(width: UIScreen.UIWidth(12))
                     
                     CustomButton2(action: {
                         viewModel.showingDialog = true

--- a/HongikYeolgong2-iOS/Scene/Container/Ready/CustomButton2.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Ready/CustomButton2.swift
@@ -21,6 +21,8 @@ struct CustomButton2: View {
         })
         .background(
             Image(image)
+                .resizable()
+                .frame(maxWidth: UIScreen.UIWidth(maxWidth), minHeight: UIScreen.UIHeight(minHeight))
                 .cornerRadius(8)
                 .background(
                     RoundedRectangle(cornerRadius: 8)

--- a/HongikYeolgong2-iOS/Scene/Container/Ready/Quote.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Ready/Quote.swift
@@ -17,8 +17,9 @@ struct Quote: View {
             }
             .padding(.bottom, UIScreen.UIHeight(16))
             
-            CustomText(font: .pretendard, title: "행동보다 빠르게 불안감을 없앨 수 있는 것은 없습니다.", textColor: .customGray100, textWeight: .regular, textSize: 18, textAlignment: .center)
+            CustomText(font: .pretendard, title: "행동보다 빠르게 불안감을 \n 없앨 수 있는 것은 없습니다.", textColor: .customGray100, textWeight: .regular, textSize: 18, textAlignment: .center)
                 .padding(.bottom, UIScreen.UIHeight(12))
+                .lineSpacing(3)
                 
             CustomText(font: .pretendard, title: "- 윌터 앤더슨", textColor: .customGray200, textWeight: .regular, textSize: 12)
         }


### PR DESCRIPTION
## AS-IS
커스텀캘린더 컴포넌트를 별도의 컴포넌트로 분리하여 사용합니다.
## TO-BE
컴포넌트를 분리함으로써 디자인의 일관성을 유지하고 코드 가독성을 향상시킵니다.
## KEY-POINT
기본 캘린더 컴포넌트는 커스텀의 제한이 많기 때문에 직접 뷰를 배치하여 커스텀 캘린더를 만들었습니다.

디자인 시안에서 동작에 대한 별도의 코멘트가 없었기 때문에 현재는 버튼을 이용한 날짜 이동만 추가했으며, Cell마다 다른 스타일을 보여주기 위해서 임의로 다른 스타일의 Cell을 보여주도록 해놨습니다.
## SCREENSHOT (Optional)

https://github.com/TeamHY2/HongikYeolgong2-iOS/assets/101062450/f1d80699-6ec4-4912-aad9-f2c9565e1ac2

