### PR TITLE
[Feature] 열람실 이용관련 도메인 로직을 작성합니다.

### DIFF
--- a/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		470027A22C50AA2500E640AE /* SUITE-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 470027922C50AA2500E640AE /* SUITE-Bold.otf */; };
 		470027A32C50AA2500E640AE /* SUITE-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 470027932C50AA2500E640AE /* SUITE-SemiBold.otf */; };
 		470027A42C50AA2500E640AE /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 470027942C50AA2500E640AE /* Pretendard-Regular.otf */; };
+		47E0A8C52C51177B009F1BA9 /* TimerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E0A8C42C51177B009F1BA9 /* TimerViewModel.swift */; };
+		47E0A8C72C511B72009F1BA9 /* CalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E0A8C62C511B72009F1BA9 /* CalendarViewModel.swift */; };
 		5E029B5A2C4157C20091249A /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E029B592C4157C20091249A /* User.swift */; };
 		5E029B5F2C4159EC0091249A /* RandomNonceString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E029B5E2C4159EC0091249A /* RandomNonceString.swift */; };
 		5E029B612C415A2D0091249A /* SHA256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E029B602C415A2D0091249A /* SHA256.swift */; };
@@ -68,7 +70,6 @@
 		8252CCDC2C40396100690D75 /* Calendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8252CCDB2C40396100690D75 /* Calendar.swift */; };
 		8252CCDE2C40440600690D75 /* CalendarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8252CCDD2C40440600690D75 /* CalendarCell.swift */; };
 		8252CCE02C404A7300690D75 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8252CCDF2C404A7300690D75 /* Day.swift */; };
-		8252CCE22C404CFE00690D75 /* CalendarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8252CCE12C404CFE00690D75 /* CalendarManager.swift */; };
 		825665792C35202E0018C799 /* MenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825665782C35202E0018C799 /* MenuViewModel.swift */; };
 		825668A52C367ED30066B216 /* CustomNavBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825668A42C367ED30066B216 /* CustomNavBarModifier.swift */; };
 		825668A72C367F130066B216 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825668A62C367F130066B216 /* View+.swift */; };
@@ -85,7 +86,6 @@
 		827C18C72C48FC5100B4AAEA /* CustomPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827C18C62C48FC5100B4AAEA /* CustomPicker.swift */; };
 		828FF2B32C3E71F1001A4ADE /* DialogModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828FF2B22C3E71F1001A4ADE /* DialogModifier.swift */; };
 		82AB4F1D2C3EBF5400787B3B /* AlertModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AB4F1C2C3EBF5400787B3B /* AlertModifier.swift */; };
-		82AB4F212C3EE9DB00787B3B /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AB4F202C3EE9DB00787B3B /* HomeViewModel.swift */; };
 		82AB4F232C3EEE6D00787B3B /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AB4F222C3EEE6D00787B3B /* Date+.swift */; };
 		82B1FE7B2C3BC567002D9163 /* Quote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B1FE7A2C3BC567002D9163 /* Quote.swift */; };
 		82B1FE812C3C1755002D9163 /* CustomButton2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B1FE802C3C1755002D9163 /* CustomButton2.swift */; };
@@ -113,6 +113,8 @@
 		470027922C50AA2500E640AE /* SUITE-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-Bold.otf"; path = "../../../../Font/SUITE-Bold.otf"; sourceTree = "<group>"; };
 		470027932C50AA2500E640AE /* SUITE-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-SemiBold.otf"; path = "../../../../Font/SUITE-SemiBold.otf"; sourceTree = "<group>"; };
 		470027942C50AA2500E640AE /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Regular.otf"; path = "../../../../Font/Pretendard-Regular.otf"; sourceTree = "<group>"; };
+		47E0A8C42C51177B009F1BA9 /* TimerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerViewModel.swift; sourceTree = "<group>"; };
+		47E0A8C62C511B72009F1BA9 /* CalendarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewModel.swift; sourceTree = "<group>"; };
 		5E029B592C4157C20091249A /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		5E029B5E2C4159EC0091249A /* RandomNonceString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomNonceString.swift; sourceTree = "<group>"; };
 		5E029B602C415A2D0091249A /* SHA256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SHA256.swift; sourceTree = "<group>"; };
@@ -133,7 +135,6 @@
 		8252CCDB2C40396100690D75 /* Calendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar.swift; sourceTree = "<group>"; };
 		8252CCDD2C40440600690D75 /* CalendarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCell.swift; sourceTree = "<group>"; };
 		8252CCDF2C404A7300690D75 /* Day.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Day.swift; sourceTree = "<group>"; };
-		8252CCE12C404CFE00690D75 /* CalendarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarManager.swift; sourceTree = "<group>"; };
 		825665782C35202E0018C799 /* MenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewModel.swift; sourceTree = "<group>"; };
 		825668A42C367ED30066B216 /* CustomNavBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavBarModifier.swift; sourceTree = "<group>"; };
 		825668A62C367F130066B216 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
@@ -150,7 +151,6 @@
 		827C18C62C48FC5100B4AAEA /* CustomPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPicker.swift; sourceTree = "<group>"; };
 		828FF2B22C3E71F1001A4ADE /* DialogModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogModifier.swift; sourceTree = "<group>"; };
 		82AB4F1C2C3EBF5400787B3B /* AlertModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertModifier.swift; sourceTree = "<group>"; };
-		82AB4F202C3EE9DB00787B3B /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		82AB4F222C3EEE6D00787B3B /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		82B1FE7A2C3BC567002D9163 /* Quote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quote.swift; sourceTree = "<group>"; };
 		82B1FE802C3C1755002D9163 /* CustomButton2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton2.swift; sourceTree = "<group>"; };
@@ -356,7 +356,7 @@
 			isa = PBXGroup;
 			children = (
 				8274CF382C33DB1000FBFA9D /* HomeView.swift */,
-				82AB4F202C3EE9DB00787B3B /* HomeViewModel.swift */,
+				47E0A8C42C51177B009F1BA9 /* TimerViewModel.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -375,7 +375,7 @@
 			children = (
 				8252CCDB2C40396100690D75 /* Calendar.swift */,
 				8252CCDD2C40440600690D75 /* CalendarCell.swift */,
-				8252CCE12C404CFE00690D75 /* CalendarManager.swift */,
+				47E0A8C62C511B72009F1BA9 /* CalendarViewModel.swift */,
 			);
 			path = Calendar;
 			sourceTree = "<group>";
@@ -596,8 +596,8 @@
 				5E029B5A2C4157C20091249A /* User.swift in Sources */,
 				8252CCDC2C40396100690D75 /* Calendar.swift in Sources */,
 				8252CCE02C404A7300690D75 /* Day.swift in Sources */,
+				47E0A8C72C511B72009F1BA9 /* CalendarViewModel.swift in Sources */,
 				82B1FE7B2C3BC567002D9163 /* Quote.swift in Sources */,
-				82AB4F212C3EE9DB00787B3B /* HomeViewModel.swift in Sources */,
 				5EE304A22C4023A40002C49E /* AuthenticationViewModel.swift in Sources */,
 				5EE304982C40204E0002C49E /* DIContainer.swift in Sources */,
 				8274CF372C33D6D600FBFA9D /* SceneCoordinatorType.swift in Sources */,
@@ -605,6 +605,7 @@
 				8270C9912C4D48A0000EB06A /* ServiceError.swift in Sources */,
 				825668A52C367ED30066B216 /* CustomNavBarModifier.swift in Sources */,
 				825668A72C367F130066B216 /* View+.swift in Sources */,
+				47E0A8C52C51177B009F1BA9 /* TimerViewModel.swift in Sources */,
 				8270C9942C4D490A000EB06A /* CalendarRepository.swift in Sources */,
 				825665792C35202E0018C799 /* MenuViewModel.swift in Sources */,
 				8252CCDE2C40440600690D75 /* CalendarCell.swift in Sources */,
@@ -613,7 +614,6 @@
 				5E5B0BD32C3289D500936435 /* UIColor+.swift in Sources */,
 				5EE304942C4015880002C49E /* LoginViewModel.swift in Sources */,
 				8274CF332C33D59400FBFA9D /* Scene.swift in Sources */,
-				8252CCE22C404CFE00690D75 /* CalendarManager.swift in Sources */,
 				82D4D6142C327BDC00A92327 /* HongikYeolgong2_iOSApp.swift in Sources */,
 				82AB4F232C3EEE6D00787B3B /* Date+.swift in Sources */,
 				5E5CD4412C369994002CE244 /* UIScreen+.swift in Sources */,

--- a/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,22 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		470027952C50AA2500E640AE /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 470027852C50AA2500E640AE /* Pretendard-Light.otf */; };
+		470027962C50AA2500E640AE /* SUITE-Heavy.otf in Resources */ = {isa = PBXBuildFile; fileRef = 470027862C50AA2500E640AE /* SUITE-Heavy.otf */; };
+		470027972C50AA2500E640AE /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 470027872C50AA2500E640AE /* Pretendard-SemiBold.otf */; };
+		470027982C50AA2500E640AE /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 470027882C50AA2500E640AE /* Pretendard-Bold.otf */; };
+		470027992C50AA2500E640AE /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = 470027892C50AA2500E640AE /* Pretendard-Thin.otf */; };
+		4700279A2C50AA2500E640AE /* SUITE-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4700278A2C50AA2500E640AE /* SUITE-ExtraBold.otf */; };
+		4700279B2C50AA2500E640AE /* Pretendard-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4700278B2C50AA2500E640AE /* Pretendard-ExtraBold.otf */; };
+		4700279C2C50AA2500E640AE /* SUITE-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4700278C2C50AA2500E640AE /* SUITE-Light.otf */; };
+		4700279D2C50AA2500E640AE /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4700278D2C50AA2500E640AE /* Pretendard-Black.otf */; };
+		4700279E2C50AA2500E640AE /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4700278E2C50AA2500E640AE /* Pretendard-Medium.otf */; };
+		4700279F2C50AA2500E640AE /* SUITE-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4700278F2C50AA2500E640AE /* SUITE-Medium.otf */; };
+		470027A02C50AA2500E640AE /* Pretendard-ExtraLight.otf in Resources */ = {isa = PBXBuildFile; fileRef = 470027902C50AA2500E640AE /* Pretendard-ExtraLight.otf */; };
+		470027A12C50AA2500E640AE /* SUITE-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 470027912C50AA2500E640AE /* SUITE-Regular.otf */; };
+		470027A22C50AA2500E640AE /* SUITE-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 470027922C50AA2500E640AE /* SUITE-Bold.otf */; };
+		470027A32C50AA2500E640AE /* SUITE-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 470027932C50AA2500E640AE /* SUITE-SemiBold.otf */; };
+		470027A42C50AA2500E640AE /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 470027942C50AA2500E640AE /* Pretendard-Regular.otf */; };
 		5E029B5A2C4157C20091249A /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E029B592C4157C20091249A /* User.swift */; };
 		5E029B5F2C4159EC0091249A /* RandomNonceString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E029B5E2C4159EC0091249A /* RandomNonceString.swift */; };
 		5E029B612C415A2D0091249A /* SHA256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E029B602C415A2D0091249A /* SHA256.swift */; };
@@ -77,26 +93,26 @@
 		82D4D6142C327BDC00A92327 /* HongikYeolgong2_iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D4D6132C327BDC00A92327 /* HongikYeolgong2_iOSApp.swift */; };
 		82D4D6182C327BDF00A92327 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 82D4D6172C327BDF00A92327 /* Assets.xcassets */; };
 		82D4D61B2C327BDF00A92327 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 82D4D61A2C327BDF00A92327 /* Preview Assets.xcassets */; };
-		82E15A5F2C481DB9004951BE /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A4F2C481DB8004951BE /* Pretendard-Black.otf */; };
-		82E15A602C481DB9004951BE /* SUITE-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A502C481DB8004951BE /* SUITE-Bold.otf */; };
-		82E15A612C481DB9004951BE /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A512C481DB9004951BE /* Pretendard-Medium.otf */; };
-		82E15A622C481DB9004951BE /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A522C481DB9004951BE /* Pretendard-Regular.otf */; };
-		82E15A632C481DB9004951BE /* SUITE-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A532C481DB9004951BE /* SUITE-ExtraBold.otf */; };
-		82E15A642C481DB9004951BE /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A542C481DB9004951BE /* Pretendard-Bold.otf */; };
-		82E15A652C481DB9004951BE /* SUITE-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A552C481DB9004951BE /* SUITE-Medium.otf */; };
-		82E15A662C481DB9004951BE /* SUITE-Heavy.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A562C481DB9004951BE /* SUITE-Heavy.otf */; };
-		82E15A672C481DB9004951BE /* Pretendard-ExtraLight.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A572C481DB9004951BE /* Pretendard-ExtraLight.otf */; };
-		82E15A682C481DB9004951BE /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A582C481DB9004951BE /* Pretendard-Light.otf */; };
-		82E15A692C481DB9004951BE /* SUITE-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A592C481DB9004951BE /* SUITE-Regular.otf */; };
-		82E15A6A2C481DB9004951BE /* SUITE-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A5A2C481DB9004951BE /* SUITE-SemiBold.otf */; };
-		82E15A6B2C481DB9004951BE /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A5B2C481DB9004951BE /* Pretendard-SemiBold.otf */; };
-		82E15A6C2C481DB9004951BE /* Pretendard-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A5C2C481DB9004951BE /* Pretendard-ExtraBold.otf */; };
-		82E15A6D2C481DB9004951BE /* SUITE-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A5D2C481DB9004951BE /* SUITE-Light.otf */; };
-		82E15A6E2C481DB9004951BE /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = 82E15A5E2C481DB9004951BE /* Pretendard-Thin.otf */; };
 		82E15A712C48218B004951BE /* DependencyWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E15A702C48218B004951BE /* DependencyWrapper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		470027852C50AA2500E640AE /* Pretendard-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Light.otf"; path = "../../../../Font/Pretendard-Light.otf"; sourceTree = "<group>"; };
+		470027862C50AA2500E640AE /* SUITE-Heavy.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-Heavy.otf"; path = "../../../../Font/SUITE-Heavy.otf"; sourceTree = "<group>"; };
+		470027872C50AA2500E640AE /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-SemiBold.otf"; path = "../../../../Font/Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
+		470027882C50AA2500E640AE /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Bold.otf"; path = "../../../../Font/Pretendard-Bold.otf"; sourceTree = "<group>"; };
+		470027892C50AA2500E640AE /* Pretendard-Thin.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Thin.otf"; path = "../../../../Font/Pretendard-Thin.otf"; sourceTree = "<group>"; };
+		4700278A2C50AA2500E640AE /* SUITE-ExtraBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-ExtraBold.otf"; path = "../../../../Font/SUITE-ExtraBold.otf"; sourceTree = "<group>"; };
+		4700278B2C50AA2500E640AE /* Pretendard-ExtraBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-ExtraBold.otf"; path = "../../../../Font/Pretendard-ExtraBold.otf"; sourceTree = "<group>"; };
+		4700278C2C50AA2500E640AE /* SUITE-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-Light.otf"; path = "../../../../Font/SUITE-Light.otf"; sourceTree = "<group>"; };
+		4700278D2C50AA2500E640AE /* Pretendard-Black.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Black.otf"; path = "../../../../Font/Pretendard-Black.otf"; sourceTree = "<group>"; };
+		4700278E2C50AA2500E640AE /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Medium.otf"; path = "../../../../Font/Pretendard-Medium.otf"; sourceTree = "<group>"; };
+		4700278F2C50AA2500E640AE /* SUITE-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-Medium.otf"; path = "../../../../Font/SUITE-Medium.otf"; sourceTree = "<group>"; };
+		470027902C50AA2500E640AE /* Pretendard-ExtraLight.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-ExtraLight.otf"; path = "../../../../Font/Pretendard-ExtraLight.otf"; sourceTree = "<group>"; };
+		470027912C50AA2500E640AE /* SUITE-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-Regular.otf"; path = "../../../../Font/SUITE-Regular.otf"; sourceTree = "<group>"; };
+		470027922C50AA2500E640AE /* SUITE-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-Bold.otf"; path = "../../../../Font/SUITE-Bold.otf"; sourceTree = "<group>"; };
+		470027932C50AA2500E640AE /* SUITE-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-SemiBold.otf"; path = "../../../../Font/SUITE-SemiBold.otf"; sourceTree = "<group>"; };
+		470027942C50AA2500E640AE /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Regular.otf"; path = "../../../../Font/Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		5E029B592C4157C20091249A /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		5E029B5E2C4159EC0091249A /* RandomNonceString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomNonceString.swift; sourceTree = "<group>"; };
 		5E029B602C415A2D0091249A /* SHA256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SHA256.swift; sourceTree = "<group>"; };
@@ -143,22 +159,6 @@
 		82D4D6132C327BDC00A92327 /* HongikYeolgong2_iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HongikYeolgong2_iOSApp.swift; sourceTree = "<group>"; };
 		82D4D6172C327BDF00A92327 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		82D4D61A2C327BDF00A92327 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
-		82E15A4F2C481DB8004951BE /* Pretendard-Black.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Black.otf"; path = "../../../../font/Pretendard-Black.otf"; sourceTree = "<group>"; };
-		82E15A502C481DB8004951BE /* SUITE-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-Bold.otf"; path = "../../../../font/SUITE-Bold.otf"; sourceTree = "<group>"; };
-		82E15A512C481DB9004951BE /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Medium.otf"; path = "../../../../font/Pretendard-Medium.otf"; sourceTree = "<group>"; };
-		82E15A522C481DB9004951BE /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Regular.otf"; path = "../../../../font/Pretendard-Regular.otf"; sourceTree = "<group>"; };
-		82E15A532C481DB9004951BE /* SUITE-ExtraBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-ExtraBold.otf"; path = "../../../../font/SUITE-ExtraBold.otf"; sourceTree = "<group>"; };
-		82E15A542C481DB9004951BE /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Bold.otf"; path = "../../../../font/Pretendard-Bold.otf"; sourceTree = "<group>"; };
-		82E15A552C481DB9004951BE /* SUITE-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-Medium.otf"; path = "../../../../font/SUITE-Medium.otf"; sourceTree = "<group>"; };
-		82E15A562C481DB9004951BE /* SUITE-Heavy.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-Heavy.otf"; path = "../../../../font/SUITE-Heavy.otf"; sourceTree = "<group>"; };
-		82E15A572C481DB9004951BE /* Pretendard-ExtraLight.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-ExtraLight.otf"; path = "../../../../font/Pretendard-ExtraLight.otf"; sourceTree = "<group>"; };
-		82E15A582C481DB9004951BE /* Pretendard-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Light.otf"; path = "../../../../font/Pretendard-Light.otf"; sourceTree = "<group>"; };
-		82E15A592C481DB9004951BE /* SUITE-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-Regular.otf"; path = "../../../../font/SUITE-Regular.otf"; sourceTree = "<group>"; };
-		82E15A5A2C481DB9004951BE /* SUITE-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-SemiBold.otf"; path = "../../../../font/SUITE-SemiBold.otf"; sourceTree = "<group>"; };
-		82E15A5B2C481DB9004951BE /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-SemiBold.otf"; path = "../../../../font/Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
-		82E15A5C2C481DB9004951BE /* Pretendard-ExtraBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-ExtraBold.otf"; path = "../../../../font/Pretendard-ExtraBold.otf"; sourceTree = "<group>"; };
-		82E15A5D2C481DB9004951BE /* SUITE-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SUITE-Light.otf"; path = "../../../../font/SUITE-Light.otf"; sourceTree = "<group>"; };
-		82E15A5E2C481DB9004951BE /* Pretendard-Thin.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Thin.otf"; path = "../../../../font/Pretendard-Thin.otf"; sourceTree = "<group>"; };
 		82E15A702C48218B004951BE /* DependencyWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyWrapper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -246,22 +246,22 @@
 		5E5B0BC72C3286C500936435 /* Font */ = {
 			isa = PBXGroup;
 			children = (
-				82E15A4F2C481DB8004951BE /* Pretendard-Black.otf */,
-				82E15A542C481DB9004951BE /* Pretendard-Bold.otf */,
-				82E15A5C2C481DB9004951BE /* Pretendard-ExtraBold.otf */,
-				82E15A572C481DB9004951BE /* Pretendard-ExtraLight.otf */,
-				82E15A582C481DB9004951BE /* Pretendard-Light.otf */,
-				82E15A512C481DB9004951BE /* Pretendard-Medium.otf */,
-				82E15A522C481DB9004951BE /* Pretendard-Regular.otf */,
-				82E15A5B2C481DB9004951BE /* Pretendard-SemiBold.otf */,
-				82E15A5E2C481DB9004951BE /* Pretendard-Thin.otf */,
-				82E15A502C481DB8004951BE /* SUITE-Bold.otf */,
-				82E15A532C481DB9004951BE /* SUITE-ExtraBold.otf */,
-				82E15A562C481DB9004951BE /* SUITE-Heavy.otf */,
-				82E15A5D2C481DB9004951BE /* SUITE-Light.otf */,
-				82E15A552C481DB9004951BE /* SUITE-Medium.otf */,
-				82E15A592C481DB9004951BE /* SUITE-Regular.otf */,
-				82E15A5A2C481DB9004951BE /* SUITE-SemiBold.otf */,
+				4700278D2C50AA2500E640AE /* Pretendard-Black.otf */,
+				470027882C50AA2500E640AE /* Pretendard-Bold.otf */,
+				4700278B2C50AA2500E640AE /* Pretendard-ExtraBold.otf */,
+				470027902C50AA2500E640AE /* Pretendard-ExtraLight.otf */,
+				470027852C50AA2500E640AE /* Pretendard-Light.otf */,
+				4700278E2C50AA2500E640AE /* Pretendard-Medium.otf */,
+				470027942C50AA2500E640AE /* Pretendard-Regular.otf */,
+				470027872C50AA2500E640AE /* Pretendard-SemiBold.otf */,
+				470027892C50AA2500E640AE /* Pretendard-Thin.otf */,
+				470027922C50AA2500E640AE /* SUITE-Bold.otf */,
+				4700278A2C50AA2500E640AE /* SUITE-ExtraBold.otf */,
+				470027862C50AA2500E640AE /* SUITE-Heavy.otf */,
+				4700278C2C50AA2500E640AE /* SUITE-Light.otf */,
+				4700278F2C50AA2500E640AE /* SUITE-Medium.otf */,
+				470027912C50AA2500E640AE /* SUITE-Regular.otf */,
+				470027932C50AA2500E640AE /* SUITE-SemiBold.otf */,
 			);
 			path = Font;
 			sourceTree = "<group>";
@@ -561,25 +561,25 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				82E15A682C481DB9004951BE /* Pretendard-Light.otf in Resources */,
-				82E15A6D2C481DB9004951BE /* SUITE-Light.otf in Resources */,
+				470027A42C50AA2500E640AE /* Pretendard-Regular.otf in Resources */,
+				470027962C50AA2500E640AE /* SUITE-Heavy.otf in Resources */,
+				470027A12C50AA2500E640AE /* SUITE-Regular.otf in Resources */,
 				82D4D61B2C327BDF00A92327 /* Preview Assets.xcassets in Resources */,
+				4700279B2C50AA2500E640AE /* Pretendard-ExtraBold.otf in Resources */,
+				4700279E2C50AA2500E640AE /* Pretendard-Medium.otf in Resources */,
+				470027982C50AA2500E640AE /* Pretendard-Bold.otf in Resources */,
+				4700279C2C50AA2500E640AE /* SUITE-Light.otf in Resources */,
+				470027992C50AA2500E640AE /* Pretendard-Thin.otf in Resources */,
+				470027952C50AA2500E640AE /* Pretendard-Light.otf in Resources */,
+				470027A32C50AA2500E640AE /* SUITE-SemiBold.otf in Resources */,
+				470027972C50AA2500E640AE /* Pretendard-SemiBold.otf in Resources */,
 				82D4D6182C327BDF00A92327 /* Assets.xcassets in Resources */,
-				82E15A6B2C481DB9004951BE /* Pretendard-SemiBold.otf in Resources */,
-				82E15A5F2C481DB9004951BE /* Pretendard-Black.otf in Resources */,
-				82E15A662C481DB9004951BE /* SUITE-Heavy.otf in Resources */,
-				82E15A602C481DB9004951BE /* SUITE-Bold.otf in Resources */,
-				82E15A6A2C481DB9004951BE /* SUITE-SemiBold.otf in Resources */,
-				82E15A622C481DB9004951BE /* Pretendard-Regular.otf in Resources */,
-				82E15A672C481DB9004951BE /* Pretendard-ExtraLight.otf in Resources */,
-				82E15A6E2C481DB9004951BE /* Pretendard-Thin.otf in Resources */,
-				82E15A652C481DB9004951BE /* SUITE-Medium.otf in Resources */,
+				4700279A2C50AA2500E640AE /* SUITE-ExtraBold.otf in Resources */,
+				4700279D2C50AA2500E640AE /* Pretendard-Black.otf in Resources */,
+				470027A02C50AA2500E640AE /* Pretendard-ExtraLight.otf in Resources */,
 				5EE304692C3FE9E90002C49E /* GoogleService-Info.plist in Resources */,
-				82E15A6C2C481DB9004951BE /* Pretendard-ExtraBold.otf in Resources */,
-				82E15A632C481DB9004951BE /* SUITE-ExtraBold.otf in Resources */,
-				82E15A692C481DB9004951BE /* SUITE-Regular.otf in Resources */,
-				82E15A642C481DB9004951BE /* Pretendard-Bold.otf in Resources */,
-				82E15A612C481DB9004951BE /* Pretendard-Medium.otf in Resources */,
+				470027A22C50AA2500E640AE /* SUITE-Bold.otf in Resources */,
+				4700279F2C50AA2500E640AE /* SUITE-Medium.otf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2-iOS.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		5E029B5A2C4157C20091249A /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E029B592C4157C20091249A /* User.swift */; };
-		5E029B5C2C4158320091249A /* ServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E029B5B2C4158320091249A /* ServiceError.swift */; };
 		5E029B5F2C4159EC0091249A /* RandomNonceString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E029B5E2C4159EC0091249A /* RandomNonceString.swift */; };
 		5E029B612C415A2D0091249A /* SHA256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E029B602C415A2D0091249A /* SHA256.swift */; };
 		5E5B0BD32C3289D500936435 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5B0BD22C3289D500936435 /* UIColor+.swift */; };
@@ -58,6 +57,9 @@
 		825668A52C367ED30066B216 /* CustomNavBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825668A42C367ED30066B216 /* CustomNavBarModifier.swift */; };
 		825668A72C367F130066B216 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825668A62C367F130066B216 /* View+.swift */; };
 		825668A92C36855A0066B216 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825668A82C36855A0066B216 /* UINavigationController+.swift */; };
+		8270C9912C4D48A0000EB06A /* ServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8270C9902C4D48A0000EB06A /* ServiceError.swift */; };
+		8270C9942C4D490A000EB06A /* CalendarRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8270C9932C4D490A000EB06A /* CalendarRepository.swift */; };
+		8270C9962C4D4AAE000EB06A /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8270C9952C4D4AAE000EB06A /* ViewModelType.swift */; };
 		8274CF332C33D59400FBFA9D /* Scene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8274CF322C33D59400FBFA9D /* Scene.swift */; };
 		8274CF352C33D6C200FBFA9D /* SceneCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8274CF342C33D6C200FBFA9D /* SceneCoordinator.swift */; };
 		8274CF372C33D6D600FBFA9D /* SceneCoordinatorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8274CF362C33D6D600FBFA9D /* SceneCoordinatorType.swift */; };
@@ -96,7 +98,6 @@
 
 /* Begin PBXFileReference section */
 		5E029B592C4157C20091249A /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
-		5E029B5B2C4158320091249A /* ServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceError.swift; sourceTree = "<group>"; };
 		5E029B5E2C4159EC0091249A /* RandomNonceString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomNonceString.swift; sourceTree = "<group>"; };
 		5E029B602C415A2D0091249A /* SHA256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SHA256.swift; sourceTree = "<group>"; };
 		5E5B0BD22C3289D500936435 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
@@ -121,6 +122,9 @@
 		825668A42C367ED30066B216 /* CustomNavBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavBarModifier.swift; sourceTree = "<group>"; };
 		825668A62C367F130066B216 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		825668A82C36855A0066B216 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
+		8270C9902C4D48A0000EB06A /* ServiceError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceError.swift; sourceTree = "<group>"; };
+		8270C9932C4D490A000EB06A /* CalendarRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarRepository.swift; sourceTree = "<group>"; };
+		8270C9952C4D4AAE000EB06A /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
 		8274CF322C33D59400FBFA9D /* Scene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scene.swift; sourceTree = "<group>"; };
 		8274CF342C33D6C200FBFA9D /* SceneCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinator.swift; sourceTree = "<group>"; };
 		8274CF362C33D6D600FBFA9D /* SceneCoordinatorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinatorType.swift; sourceTree = "<group>"; };
@@ -325,6 +329,7 @@
 				8274CF2F2C33D3DB00FBFA9D /* Coordinator */,
 				5E5B0BC62C3286A600936435 /* Extension */,
 				825668A12C3672C80066B216 /* Modifiers */,
+				8270C9952C4D4AAE000EB06A /* ViewModelType.swift */,
 			);
 			path = General;
 			sourceTree = "<group>";
@@ -333,7 +338,7 @@
 			isa = PBXGroup;
 			children = (
 				5EE3049C2C4022990002C49E /* AuthenticationService.swift */,
-				5E029B5B2C4158320091249A /* ServiceError.swift */,
+				8270C9902C4D48A0000EB06A /* ServiceError.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -385,6 +390,14 @@
 			path = Modifiers;
 			sourceTree = "<group>";
 		};
+		8270C9922C4D48B6000EB06A /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				8270C9932C4D490A000EB06A /* CalendarRepository.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
 		8274CF2F2C33D3DB00FBFA9D /* Coordinator */ = {
 			isa = PBXGroup;
 			children = (
@@ -419,6 +432,7 @@
 				5E8F934C2C416DF300ECE6C5 /* HongikYeolgong2-iOSDebug.entitlements */,
 				5EE304952C401A160002C49E /* HongikYeolgong2-iOSRelease.entitlements */,
 				82E15A4E2C481D02004951BE /* Resources */,
+				8270C9922C4D48B6000EB06A /* Repositories */,
 				5E5B0BC42C32866900936435 /* Model */,
 				5EE304992C4020900002C49E /* Services */,
 				5EE304962C4020230002C49E /* General */,
@@ -585,12 +599,13 @@
 				82B1FE7B2C3BC567002D9163 /* Quote.swift in Sources */,
 				82AB4F212C3EE9DB00787B3B /* HomeViewModel.swift in Sources */,
 				5EE304A22C4023A40002C49E /* AuthenticationViewModel.swift in Sources */,
-				5E029B5C2C4158320091249A /* ServiceError.swift in Sources */,
 				5EE304982C40204E0002C49E /* DIContainer.swift in Sources */,
 				8274CF372C33D6D600FBFA9D /* SceneCoordinatorType.swift in Sources */,
 				827C18C72C48FC5100B4AAEA /* CustomPicker.swift in Sources */,
+				8270C9912C4D48A0000EB06A /* ServiceError.swift in Sources */,
 				825668A52C367ED30066B216 /* CustomNavBarModifier.swift in Sources */,
 				825668A72C367F130066B216 /* View+.swift in Sources */,
+				8270C9942C4D490A000EB06A /* CalendarRepository.swift in Sources */,
 				825665792C35202E0018C799 /* MenuViewModel.swift in Sources */,
 				8252CCDE2C40440600690D75 /* CalendarCell.swift in Sources */,
 				5E89D79A2C35855F00C9CB71 /* Font+.swift in Sources */,
@@ -603,6 +618,7 @@
 				82AB4F232C3EEE6D00787B3B /* Date+.swift in Sources */,
 				5E5CD4412C369994002CE244 /* UIScreen+.swift in Sources */,
 				8274CF3D2C33DE2300FBFA9D /* MenuView.swift in Sources */,
+				8270C9962C4D4AAE000EB06A /* ViewModelType.swift in Sources */,
 				8274CF352C33D6C200FBFA9D /* SceneCoordinator.swift in Sources */,
 				5EE304A02C4023960002C49E /* AuthenticationView.swift in Sources */,
 				5E029B5F2C4159EC0091249A /* RandomNonceString.swift in Sources */,

--- a/HongikYeolgong2-iOS/General/Extension/View+.swift
+++ b/HongikYeolgong2-iOS/General/Extension/View+.swift
@@ -111,14 +111,26 @@ extension View {
     func dialog(isPresented: Binding<Bool>, currentDate: Binding<Date>, confirmAction: @escaping () -> (), cancelAction: @escaping () -> ()) -> some View {
         modifier(DialogModifier(isPresented: isPresented, currentDate: currentDate, confirmAction: confirmAction, cancelAction: cancelAction))
     }
+    
+    func dialog(isPresented: Binding<Bool>, currentDate: Binding<Date>, confirmAction: @escaping () -> ()) -> some View {
+        modifier(DialogModifier(isPresented: isPresented, currentDate: currentDate, confirmAction: confirmAction))
+    }
 }
 
 extension View {
-    func alert(title: String, isPresented: Binding<Bool>, confirmAction: @escaping () -> (), cancelAction: @escaping () -> ()) -> some View {
+    func alert(title: String, isPresented: Binding<Bool>, confirmAction: (() -> Void)?, cancelAction: (() -> Void)?) -> some View {
         modifier(AlertModifier(title: title, confirmAction: confirmAction, cancleAction: cancelAction, isPresented: isPresented))
     }
     
-    func alert(title: String, confirmButtonText: String, cancleButtonText: String, isPresented: Binding<Bool>, confirmAction: @escaping () -> (), cancelAction: @escaping () -> ()) -> some View {
+    func alert(title: String, isPresented: Binding<Bool>, confirmAction: (() -> Void)?) -> some View {
+        modifier(AlertModifier(title: title, confirmAction: confirmAction, isPresented: isPresented))
+    }
+    
+    func alert(title: String, confirmButtonText: String, cancleButtonText: String, isPresented: Binding<Bool>, confirmAction: (() -> Void)?, cancelAction: (() -> Void)?) -> some View {
         modifier(AlertModifier(title: title, confirmButtonText: confirmButtonText, cancleButtonText: cancleButtonText, confirmAction: confirmAction, cancleAction: cancelAction, isPresented: isPresented))
+    }
+    
+    func alert(title: String, confirmButtonText: String, cancleButtonText: String, isPresented: Binding<Bool>, confirmAction: (() -> Void)?) -> some View {
+        modifier(AlertModifier(title: title, confirmButtonText: confirmButtonText, cancleButtonText: cancleButtonText, confirmAction: confirmAction, isPresented: isPresented))
     }
 }

--- a/HongikYeolgong2-iOS/General/Modifiers/AlertModifier.swift
+++ b/HongikYeolgong2-iOS/General/Modifiers/AlertModifier.swift
@@ -8,14 +8,35 @@
 import SwiftUI
 import Combine
 struct AlertModifier: ViewModifier {
-    let title: String
+    
     var confirmButtonText: String = "네"
     var cancleButtonText: String = "아니오"
+    
+    let title: String
     let confirmAction: (() -> ())?
     let cancleAction: (() -> ())?
+    
     @State private var scale: CGFloat = 1
     
     @Binding var isPresented: Bool
+    
+    init(title: String, confirmButtonText: String, cancleButtonText: String, confirmAction: (() -> Void)?, cancleAction: (() -> Void)? = nil, isPresented: Binding<Bool>) {
+        self.confirmButtonText = confirmButtonText
+        self.cancleButtonText = cancleButtonText
+        self.title = title
+        self.confirmAction = confirmAction
+        self.cancleAction = cancleAction
+        self._isPresented = isPresented
+    }
+    
+    init(title: String, confirmAction: (() -> Void)?, cancleAction: (() -> Void)? = nil, isPresented: Binding<Bool>) {
+        self.title = title
+        self.confirmAction = confirmAction
+        self.cancleAction = cancleAction
+        self._isPresented = isPresented
+    }
+    
+    
     func body(content: Content) -> some View {
         content
             .overlay(

--- a/HongikYeolgong2-iOS/General/Modifiers/DialogModifier.swift
+++ b/HongikYeolgong2-iOS/General/Modifiers/DialogModifier.swift
@@ -27,7 +27,7 @@ struct DialogModifier: ViewModifier {
     let confirmAction: (() -> ())?
     let cancleAction: (() -> ())?
     
-    init(isPresented: Binding<Bool>, currentDate: Binding<Date>, confirmAction: @escaping () -> (), cancelAction: @escaping () -> ()) {
+    init(isPresented: Binding<Bool>, currentDate: Binding<Date>, confirmAction: @escaping () -> (), cancelAction: (() -> ())? = nil) {
         self._isPresented = isPresented
         self._currentDate = currentDate
         self.confirmAction = confirmAction

--- a/HongikYeolgong2-iOS/General/ViewModelType.swift
+++ b/HongikYeolgong2-iOS/General/ViewModelType.swift
@@ -1,0 +1,14 @@
+//
+//  ViewModelType.swift
+//  HongikYeolgong2-iOS
+//
+//  Created by 석기권 on 7/21/24.
+//
+
+import Foundation
+import Combine
+
+protocol ViewModelType: ObservableObject  {
+    associatedtype Action
+    func send(action: Action)
+}

--- a/HongikYeolgong2-iOS/Model/Day.swift
+++ b/HongikYeolgong2-iOS/Model/Day.swift
@@ -13,8 +13,7 @@ struct Day: Identifiable {
     var studyRecord: [StudyRecord]?
 }
 
-struct StudyRecord: Identifiable {
-    let id = UUID().uuidString
+struct StudyRecord {
     let date: Date
     let totalTime: Int
 }

--- a/HongikYeolgong2-iOS/Model/Day.swift
+++ b/HongikYeolgong2-iOS/Model/Day.swift
@@ -9,6 +9,15 @@ import Foundation
 
 struct Day: Identifiable {
     var id = UUID().uuidString
-    
     let dayOfNumber: String
+    var studyRecord: [StudyRecord]?
 }
+
+struct StudyRecord: Identifiable {
+    let id = UUID().uuidString
+    let date: Date
+    let totalTime: Int
+}
+
+
+

--- a/HongikYeolgong2-iOS/Repositories/CalendarRepository.swift
+++ b/HongikYeolgong2-iOS/Repositories/CalendarRepository.swift
@@ -15,20 +15,14 @@ protocol CalendarRepositoryType {
 
 // 테스트용 데이터
 class CalendarRepositoryMock: CalendarRepositoryType {
-    let mockData = CurrentValueSubject<[StudyRecord], Never>([.init(date: Date() - TimeInterval(86400 * 2), totalTime: (3600 * 4)),
-                                                     .init(date: Date() - TimeInterval(86400 * 3), totalTime: (3600 * 1)),
-                                                     .init(date: Date() - TimeInterval(86400 * 5), totalTime: (3600 * 4)),
-                                                     .init(date: Date() - TimeInterval(86400 * 10), totalTime: (3600 * 2)),
-                                                     .init(date: Date() - TimeInterval(86400 * 22), totalTime: (3600 * 12)),
-                                                     .init(date: Date() - TimeInterval(86400 * 6), totalTime: (3600 * 6)),
-                                                     .init(date: Date() - TimeInterval(86400 * 7), totalTime: (3600 * 7)),])
+    let mockData = CurrentValueSubject<[StudyRecord], Never>([])
     
     func fetchStudyRecord() -> AnyPublisher<[StudyRecord], Never> {
-        return mockData.eraseToAnyPublisher()
+        return Just(mockData.value).eraseToAnyPublisher()
     }
     
     func updateStudyRecord(_ data: StudyRecord) -> AnyPublisher<[StudyRecord], Never> {        
         mockData.send(mockData.value + [data])
-        return mockData.eraseToAnyPublisher()
+        return Just(mockData.value).eraseToAnyPublisher()
     }
 }

--- a/HongikYeolgong2-iOS/Repositories/CalendarRepository.swift
+++ b/HongikYeolgong2-iOS/Repositories/CalendarRepository.swift
@@ -1,0 +1,25 @@
+//
+//  CalendarRepository.swift
+//  HongikYeolgong2-iOS
+//
+//  Created by 석기권 on 7/21/24.
+//
+
+import Foundation
+import Combine
+
+protocol CalendarRepositoryType {
+    func fetch() -> AnyPublisher<[Day], Never>
+    func insert() -> AnyPublisher<Void, Never>
+}
+
+class CalendarRepositoryMock: CalendarRepositoryType {
+    let mockData: [Day] = []
+    func fetch() -> AnyPublisher<[Day], Never> {
+        Just(mockData).eraseToAnyPublisher()
+    }
+    
+    func insert() -> AnyPublisher<Void, Never> {
+        Just(()).eraseToAnyPublisher()
+    }
+}

--- a/HongikYeolgong2-iOS/Repositories/CalendarRepository.swift
+++ b/HongikYeolgong2-iOS/Repositories/CalendarRepository.swift
@@ -9,17 +9,26 @@ import Foundation
 import Combine
 
 protocol CalendarRepositoryType {
-    func fetch() -> AnyPublisher<[Day], Never>
-    func insert() -> AnyPublisher<Void, Never>
+    func fetchStudyRecord() -> AnyPublisher<[StudyRecord], Never>
+    func updateStudyRecord(for: Date, _: StudyRecord) -> AnyPublisher<[StudyRecord], Never>
 }
 
+// 테스트용 데이터
 class CalendarRepositoryMock: CalendarRepositoryType {
-    let mockData: [Day] = []
-    func fetch() -> AnyPublisher<[Day], Never> {
-        Just(mockData).eraseToAnyPublisher()
+    let mockData = CurrentValueSubject<[StudyRecord], Never>([.init(date: Date() - TimeInterval(86400 * 2), totalTime: (3600 * 4)),
+                                                     .init(date: Date() - TimeInterval(86400 * 3), totalTime: (3600 * 1)),
+                                                     .init(date: Date() - TimeInterval(86400 * 5), totalTime: (3600 * 4)),
+                                                     .init(date: Date() - TimeInterval(86400 * 10), totalTime: (3600 * 2)),
+                                                     .init(date: Date() - TimeInterval(86400 * 22), totalTime: (3600 * 12)),
+                                                     .init(date: Date() - TimeInterval(86400 * 6), totalTime: (3600 * 6)),
+                                                     .init(date: Date() - TimeInterval(86400 * 7), totalTime: (3600 * 7)),])
+    
+    func fetchStudyRecord() -> AnyPublisher<[StudyRecord], Never> {
+        return mockData.eraseToAnyPublisher()
     }
     
-    func insert() -> AnyPublisher<Void, Never> {
-        Just(()).eraseToAnyPublisher()
+    func updateStudyRecord(for date: Date, _ data: StudyRecord) -> AnyPublisher<[StudyRecord], Never> {
+        mockData.send([data])
+        return mockData.eraseToAnyPublisher()
     }
 }

--- a/HongikYeolgong2-iOS/Repositories/CalendarRepository.swift
+++ b/HongikYeolgong2-iOS/Repositories/CalendarRepository.swift
@@ -10,7 +10,7 @@ import Combine
 
 protocol CalendarRepositoryType {
     func fetchStudyRecord() -> AnyPublisher<[StudyRecord], Never>
-    func updateStudyRecord(for: Date, _: StudyRecord) -> AnyPublisher<[StudyRecord], Never>
+    func updateStudyRecord(_: StudyRecord) -> AnyPublisher<[StudyRecord], Never>
 }
 
 // 테스트용 데이터
@@ -27,8 +27,8 @@ class CalendarRepositoryMock: CalendarRepositoryType {
         return mockData.eraseToAnyPublisher()
     }
     
-    func updateStudyRecord(for date: Date, _ data: StudyRecord) -> AnyPublisher<[StudyRecord], Never> {
-        mockData.send([data])
+    func updateStudyRecord(_ data: StudyRecord) -> AnyPublisher<[StudyRecord], Never> {        
+        mockData.send(mockData.value + [data])
         return mockData.eraseToAnyPublisher()
     }
 }

--- a/HongikYeolgong2-iOS/Scene/App/HongikYeolgong2_iOSApp.swift
+++ b/HongikYeolgong2-iOS/Scene/App/HongikYeolgong2_iOSApp.swift
@@ -13,7 +13,8 @@ struct HongikYeolgong2_iOSApp: App {
             AuthenticationView()
                 .environmentObject(SceneCoordinator())
                 .environmentObject(AuthenticationViewModel())
-                .environmentObject(HomeViewModel())
+                .environmentObject(TimerViewModel())
+                .environmentObject(CalendarViewModel())
         }
     }
 }

--- a/HongikYeolgong2-iOS/Scene/App/HongikYeolgong2_iOSApp.swift
+++ b/HongikYeolgong2-iOS/Scene/App/HongikYeolgong2_iOSApp.swift
@@ -32,4 +32,5 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
 func registerDependency() {
     DIContainer.shared.register(AuthenticationService() as AuthenticationServiceType)
+    DIContainer.shared.register(CalendarRepositoryMock() as CalendarRepositoryType)
 }

--- a/HongikYeolgong2-iOS/Scene/Container/Calendar/Calendar.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Calendar/Calendar.swift
@@ -8,19 +8,10 @@
 import SwiftUI
 import Combine
 
-enum WeekDay: String, CaseIterable {
-    case sun = "Sun"
-    case Mon = "Mon"
-    case Tue = "Tue"
-    case Wed = "Wed"
-    case Thu = "Thu"
-    case Fri = "Fri"
-    case Sat = "Sat"
-}
+
 
 struct CalendarView: View {
-    @State private var selecteDate = Date()
-    @State private var currentMonth = [Day]()
+    @EnvironmentObject private var viewModel: CalendarViewModel
     
     private let columns = [GridItem(.flexible()),
                            GridItem(.flexible()),
@@ -34,14 +25,14 @@ struct CalendarView: View {
         VStack(spacing: 0) {
             // header
             HStack(spacing: 0) {
-                CustomText(font: .suite, title: selecteDate.getMonthString(), textColor: .customGray100, textWeight: .bold, textSize: 24)
+                CustomText(font: .suite, title: viewModel.selecteDate.getMonthString(), textColor: .customGray100, textWeight: .bold, textSize: 24)
                     .frame(width: UIScreen.UIWidth(54))
                 
-                CustomText(font: .suite, title: selecteDate.getYearString(), textColor: .customGray100, textWeight: .bold, textSize: 24)
+                CustomText(font: .suite, title: viewModel.selecteDate.getYearString(), textColor: .customGray100, textWeight: .bold, textSize: 24)
                 Spacer()
                 HStack {
                     Button(action: {
-                        selecteDate = CalendarManager.shared.minusMonth(date: selecteDate)
+                        viewModel.send(action: .move(.prev))
                     }) {
                         Image(.icCalendarLeft)
                     }
@@ -49,7 +40,7 @@ struct CalendarView: View {
                     Spacer().frame(width: UIScreen.UIWidth(7))
                     
                     Button(action: {
-                        selecteDate = CalendarManager.shared.plusMonth(date: selecteDate)
+                        viewModel.send(action: .move(.next))
                     }) {
                         Image(.icCalendarRight)
                     }
@@ -70,22 +61,13 @@ struct CalendarView: View {
             // seleteMonth가 변경될때마다 makeMonth의 값을 받아서 currentMonth에 업데이트
             // grid
             LazyVGrid(columns: columns, spacing: UIScreen.UIWidth(5)) {
-                ForEach(currentMonth, id: \.id) {
+                ForEach(viewModel.currentMonth, id: \.id) {
                     CalendarCell(dayOfNumber: $0.dayOfNumber)
                 }
             }
             .onAppear {
-                CalendarManager.shared
-                    .makeMonth(date: selecteDate)
-                    .assign(to: \.currentMonth, on: self)
-                    .cancel()
-            }
-            .onChange(of: selecteDate) { date in
-                CalendarManager.shared
-                    .makeMonth(date: date)
-                    .assign(to: \.currentMonth, on: self)
-                    .cancel()
-            }
+                viewModel.send(action: .viewOnAppear)
+            }           
         }
     }
 }

--- a/HongikYeolgong2-iOS/Scene/Container/Calendar/Calendar.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Calendar/Calendar.swift
@@ -8,9 +8,18 @@
 import SwiftUI
 import Combine
 
-
+enum WeekDay: String, CaseIterable {
+    case sun = "Sun"
+    case Mon = "Mon"
+    case Tue = "Tue"
+    case Wed = "Wed"
+    case Thu = "Thu"
+    case Fri = "Fri"
+    case Sat = "Sat"
+}
 
 struct CalendarView: View {
+    
     @EnvironmentObject private var viewModel: CalendarViewModel
     
     private let columns = [GridItem(.flexible()),
@@ -62,7 +71,7 @@ struct CalendarView: View {
             // grid
             LazyVGrid(columns: columns, spacing: UIScreen.UIWidth(5)) {
                 ForEach(viewModel.currentMonth, id: \.id) {
-                    CalendarCell(dayOfNumber: $0.dayOfNumber)
+                    CalendarCell(dayInfo: $0)
                 }
             }
             .onAppear {

--- a/HongikYeolgong2-iOS/Scene/Container/Calendar/Calendar.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Calendar/Calendar.swift
@@ -41,7 +41,7 @@ struct CalendarView: View {
                 Spacer()
                 HStack {
                     Button(action: {
-                        viewModel.send(action: .move(.prev))
+                        viewModel.send(action: .moveButtonTap(.prev))
                     }) {
                         Image(.icCalendarLeft)
                     }
@@ -49,7 +49,7 @@ struct CalendarView: View {
                     Spacer().frame(width: UIScreen.UIWidth(7))
                     
                     Button(action: {
-                        viewModel.send(action: .move(.next))
+                        viewModel.send(action: .moveButtonTap(.next))
                     }) {
                         Image(.icCalendarRight)
                     }

--- a/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarCell.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarCell.swift
@@ -26,11 +26,11 @@ struct CalendarCell: View {
     }
     
     private var cellStyle: CellStyle {
-        if totalTime < (3600 * 3) {
+        if totalTime == 0 {
             return .dayCount00
-        } else if totalTime < (3600 * 6) {
+        } else if totalTime < (10) {
             return .dayCount01
-        } else if totalTime < ( 3600 * 9) {
+        } else if totalTime < (20) {
             return .dayCount02
         } else {
             return .dayCount03

--- a/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarCell.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarCell.swift
@@ -15,54 +15,70 @@ enum CellStyle: CaseIterable {
 }
 
 struct CalendarCell: View {
-    let dayOfNumber: String
-    let cellStyle: CellStyle = .dayCount00
+    let dayInfo: Day
+    
+    private var totalTime: Int {
+        if let stduyRecords = dayInfo.studyRecord {
+            return stduyRecords.map { $0.totalTime }.reduce(0, +)
+        } else {
+            return 0
+        }
+    }
+    
+    private var cellStyle: CellStyle {
+        if totalTime < (3600 * 3) {
+            return .dayCount00
+        } else if totalTime < (3600 * 6) {
+            return .dayCount01
+        } else if totalTime < ( 3600 * 9) {
+            return .dayCount02
+        } else {
+            return .dayCount03
+        }
+    }
     
     var body: some View {
-        
         switch cellStyle {
         case .dayCount00:
             VStack {
-                CustomText(font: .suite, title: dayOfNumber, textColor: .customGray300, textWeight: .medium, textSize: 14)
+                CustomText(font: .suite, title: dayInfo.dayOfNumber, textColor: .customGray300, textWeight: .medium, textSize: 14)
             }
             .frame(maxWidth: .infinity)
             .frame(height: UIScreen.UIHeight(33))
             .background(Color(.customGray800))
             .cornerRadius(8)
-            .opacity(dayOfNumber.isEmpty ? 0 : 1)
+            .opacity(dayInfo.dayOfNumber.isEmpty ? 0 : 1)
         case .dayCount01:
             VStack {
-                CustomText(font: .suite, title: dayOfNumber, textColor: .customGray100, textWeight: .medium, textSize: 14)
+                CustomText(font: .suite, title: dayInfo.dayOfNumber, textColor: .customGray100, textWeight: .medium, textSize: 14)
             }
             .frame(maxWidth: .infinity)
             .frame(height: UIScreen.UIHeight(33))
             .background(Image(.dayCount01))
             .cornerRadius(8)
-            .opacity(dayOfNumber.isEmpty ? 0 : 1)
+            .opacity(dayInfo.dayOfNumber.isEmpty ? 0 : 1)
         case .dayCount02:
             VStack {
-                CustomText(font: .suite, title: dayOfNumber, textColor: .white, textWeight: .medium, textSize: 14)
+                CustomText(font: .suite, title: dayInfo.dayOfNumber, textColor: .white, textWeight: .medium, textSize: 14)
             }
             .frame(maxWidth: .infinity)
             .frame(height: UIScreen.UIHeight(33))
             .background(Image(.dayCount02))
             .cornerRadius(8)
-            .opacity(dayOfNumber.isEmpty ? 0 : 1)
+            .opacity(dayInfo.dayOfNumber.isEmpty ? 0 : 1)
         case .dayCount03:
             VStack {
-                CustomText(font: .suite, title: dayOfNumber, textColor: .customGray600, textWeight: .medium, textSize: 14)
+                CustomText(font: .suite, title: dayInfo.dayOfNumber, textColor: .customGray600, textWeight: .medium, textSize: 14)
             }
             .frame(maxWidth: .infinity)
             .frame(height: UIScreen.UIHeight(33))
             .background(Image(.dayCount03))
             .cornerRadius(8)
-            .opacity(dayOfNumber.isEmpty ? 0 : 1)
+            .opacity(dayInfo.dayOfNumber.isEmpty ? 0 : 1)
         }
-        
-        
     }
 }
 
 #Preview {
-    CalendarCell(dayOfNumber: "1")
+    CalendarCell(dayInfo: Day(dayOfNumber: "1"))
 }

--- a/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarViewModel.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarViewModel.swift
@@ -26,7 +26,7 @@ final class CalendarViewModel: ViewModelType {
     private var cancellables = Set<AnyCancellable>()
     
     enum Action {
-        case saveData(StudyRecord)
+        case saveButtonTap(StudyRecord)
         case move(MoveType)
         case viewOnAppear
     }
@@ -37,7 +37,7 @@ final class CalendarViewModel: ViewModelType {
             changeMonth(moveType)
         case .viewOnAppear:
              getMonth()
-        case .saveData(let data):
+        case .saveButtonTap(let data):
             updateStudyRecord(data)
         }
     }

--- a/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarViewModel.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarViewModel.swift
@@ -26,6 +26,7 @@ final class CalendarViewModel: ViewModelType {
     private var cancellables = Set<AnyCancellable>()
     
     enum Action {
+        case saveData(StudyRecord)
         case move(MoveType)
         case viewOnAppear
     }
@@ -36,6 +37,8 @@ final class CalendarViewModel: ViewModelType {
             changeMonth(moveType)
         case .viewOnAppear:
              getMonth()
+        case .saveData(let data):
+            updateStudyRecord(data)
         }
     }
 }
@@ -60,6 +63,7 @@ extension CalendarViewModel {
         fetchStudyRecord(for: selecteDate)
     }
     
+    // 캘린더에 데이터 가져오기
     func fetchStudyRecord(for date: Date) {
         calendarRepository.fetchStudyRecord()
             .sink { completion in
@@ -67,6 +71,18 @@ extension CalendarViewModel {
             } receiveValue: { [weak self] studyArray in
                 guard let self = self else { return }
                 currentMonth = makeMonth(date: date, studyArray: studyArray)
+            }
+            .store(in: &cancellables)
+    }
+    
+    // 캘린더 데이터 저장
+    func updateStudyRecord(_ data: StudyRecord) {
+        calendarRepository.updateStudyRecord(data)
+            .sink { completion in
+                
+            } receiveValue: { [weak self] studyArray in
+                guard let self = self else { return }
+                currentMonth = makeMonth(date: selecteDate, studyArray: studyArray)
             }
             .store(in: &cancellables)
     }

--- a/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarViewModel.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Calendar/CalendarViewModel.swift
@@ -27,13 +27,13 @@ final class CalendarViewModel: ViewModelType {
     
     enum Action {
         case saveButtonTap(StudyRecord)
-        case move(MoveType)
+        case moveButtonTap(MoveType)
         case viewOnAppear
     }
     
     func send(action: Action) {
         switch action {
-        case .move(let moveType):
+        case .moveButtonTap(let moveType):
             changeMonth(moveType)
         case .viewOnAppear:
              getMonth()
@@ -46,14 +46,32 @@ final class CalendarViewModel: ViewModelType {
 extension CalendarViewModel {
     // 선택한 달이 변경되는 경우
     func changeMonth(_ moveType: MoveType) {
+        var seletedDate: Date!
+        
         switch moveType {
         case .current:
-            selecteDate = Date()
+            seletedDate = Date()
         case .next:
-            selecteDate = plusMonth(date: selecteDate)
+            seletedDate = plusMonth(date: selecteDate)
         case .prev:
-            selecteDate = minusMonth(date: selecteDate)
+            seletedDate = minusMonth(date: selecteDate)
         }
+        
+        // 현재보다 더 미래의 월이 선택된 경우
+        let maximumDateValidate = calendar.compare(seletedDate, to: Date(), toGranularity: .month)
+        
+        // 날짜이동 최소값 날짜생성
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy/MM"
+        let minimumDate = formatter.date(from: "2021/01")!
+        let mimumDateValidate = calendar.compare(seletedDate, to: minimumDate, toGranularity: .month)
+        
+        guard maximumDateValidate != .orderedDescending,
+              mimumDateValidate != .orderedAscending else {
+            return
+        }
+        
+        selecteDate = seletedDate
         
         fetchStudyRecord(for: selecteDate)
     }

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -78,21 +78,15 @@ struct HomeView: View {
             })
         })
         .dialog(isPresented: $viewModel.showingDialog,
-                currentDate: $viewModel.useageStartTime,
-                confirmAction: {
+                currentDate: $viewModel.useageStartTime) {
             viewModel.send(action: .startUsing)
-        }, cancelAction: {
-        })
-        .alert(title: "열람실을 다 이용하셨나요?", confirmButtonText: "네", cancleButtonText: "더 이용하기", isPresented: $viewModel.showingAlert, confirmAction: {
+        }
+        .alert(title: "열람실을 다 이용하셨나요?", confirmButtonText: "네", cancleButtonText: "더 이용하기", isPresented: $viewModel.showingAlert) {
             viewModel.send(action: .useCompleted)
-        }, cancelAction: {
+        }
+        .alert(title: "열람실 이용 시간을 연장할까요?", confirmButtonText: "연장하기", cancleButtonText: "아니오", isPresented: $viewModel.showingAlert2) {
             
-        })
-        .alert(title: "열람실 이용 시간을 연장할까요?", confirmButtonText: "연장하기", cancleButtonText: "아니오", isPresented: $viewModel.showingAlert2, confirmAction: {
-            
-        }, cancelAction: {
-            
-        })
+        }
     }
 }
 

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -9,33 +9,33 @@ import SwiftUI
 
 struct HomeView: View {
     @EnvironmentObject private var coordinator: SceneCoordinator
-    @EnvironmentObject private var viewModel: HomeViewModel
+    @EnvironmentObject private var timerViewModel: TimerViewModel
     
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
-                .frame(height: viewModel.isBooked ? UIScreen.UIHeight(11) : UIScreen.UIHeight(43))
+                .frame(height: timerViewModel.isStart ? UIScreen.UIHeight(11) : UIScreen.UIHeight(43))
             
-            if viewModel.isBooked {
-                TimeLapse(startTime: viewModel.startTime, 
-                          endTime: viewModel.endTime,
-                          timeRemaining: viewModel.timeRemaining)
+            if timerViewModel.isStart {
+                TimeLapse(startTime: timerViewModel.startTime,
+                          endTime: timerViewModel.endTime,
+                          timeRemaining: timerViewModel.timeRemaining)
             } else {
                 Quote()
             }
             
             Spacer()
-                .frame(height: viewModel.isBooked ? UIScreen.UIHeight(28) : UIScreen.UIHeight(120))
+                .frame(height: timerViewModel.isStart ? UIScreen.UIHeight(28) : UIScreen.UIHeight(120))
             
-            if viewModel.isBooked {
+            if timerViewModel.isStart {
                 CustomButton(action: {
-                    viewModel.send(action: .showAlert2)
+                    timerViewModel.send(action: .showAlert2)
                 }, font: .suite, title: "열람실 이용 연장", titleColor: .white, backgroundColor: .customBlue100, leading: 0, trailing: 0)
                 
                 Spacer().frame(height: UIScreen.UIHeight(12))
                 
                 CustomButton(action: {
-                    viewModel.send(action: .showAlert)
+                    timerViewModel.send(action: .showAlert)
                 }, font: .suite, title: "열람실 이용 종료", titleColor: .customGray100, backgroundColor: .customGray600, leading: 0, trailing: 0)
             } else {
                 HStack {
@@ -44,7 +44,7 @@ struct HomeView: View {
                     Spacer().frame(width: UIScreen.UIWidth(12))
                     
                     CustomButton2(action: {
-                        viewModel.send(action: .showDialog)
+                        timerViewModel.send(action: .showDialog)
                     }, title: "열람실 이용 시작", image: .angularButton02, maxWidth: .infinity, minHeight: 52)
                 }
                 
@@ -79,14 +79,14 @@ struct HomeView: View {
                 Image(.icHamburger)
             })
         })
-        .dialog(isPresented: $viewModel.showingDialog,
-                currentDate: $viewModel.startTime) {
-            viewModel.send(action: .startUsing)
+        .dialog(isPresented: $timerViewModel.showingDialog,
+                currentDate: $timerViewModel.startTime) {
+            timerViewModel.send(action: .startUsing)
         }
-        .alert(title: "열람실을 다 이용하셨나요?", confirmButtonText: "네", cancleButtonText: "더 이용하기", isPresented: $viewModel.showingAlert) {
-            viewModel.send(action: .useCompleted)
+        .alert(title: "열람실을 다 이용하셨나요?", confirmButtonText: "네", cancleButtonText: "더 이용하기", isPresented: $timerViewModel.showingAlert) {
+            timerViewModel.send(action: .useCompleted)
         }
-        .alert(title: "열람실 이용 시간을 연장할까요?", confirmButtonText: "연장하기", cancleButtonText: "아니오", isPresented: $viewModel.showingAlert2) {
+        .alert(title: "열람실 이용 시간을 연장할까요?", confirmButtonText: "연장하기", cancleButtonText: "아니오", isPresented: $timerViewModel.showingAlert2) {
             
         }
     }

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -17,7 +17,9 @@ struct HomeView: View {
                 .frame(height: viewModel.isBooked ? UIScreen.UIHeight(11) : UIScreen.UIHeight(43))
             
             if viewModel.isBooked {
-                TimeLapse(startTime: viewModel.useageStartTime, endTime: viewModel.useageStartTime + TimeInterval(3600 * 4))
+                TimeLapse(startTime: viewModel.startTime, 
+                          endTime: viewModel.endTime,
+                          timeRemaining: viewModel.timeRemaining)
             } else {
                 Quote()
             }
@@ -78,7 +80,7 @@ struct HomeView: View {
             })
         })
         .dialog(isPresented: $viewModel.showingDialog,
-                currentDate: $viewModel.useageStartTime) {
+                currentDate: $viewModel.startTime) {
             viewModel.send(action: .startUsing)
         }
         .alert(title: "열람실을 다 이용하셨나요?", confirmButtonText: "네", cancleButtonText: "더 이용하기", isPresented: $viewModel.showingAlert) {

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -14,26 +14,26 @@ struct HomeView: View {
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
-                .frame(height: viewModel.isRoomReserved ? UIScreen.UIHeight(11) : UIScreen.UIHeight(43))
+                .frame(height: viewModel.isBooked ? UIScreen.UIHeight(11) : UIScreen.UIHeight(43))
             
-            if viewModel.isRoomReserved {
+            if viewModel.isBooked {
                 TimeLapse(startTime: viewModel.useageStartTime, endTime: viewModel.useageStartTime + TimeInterval(3600 * 4))
             } else {
                 Quote()
             }
             
             Spacer()
-                .frame(height: viewModel.isRoomReserved ? UIScreen.UIHeight(28) : UIScreen.UIHeight(120))
+                .frame(height: viewModel.isBooked ? UIScreen.UIHeight(28) : UIScreen.UIHeight(120))
             
-            if viewModel.isRoomReserved {
+            if viewModel.isBooked {
                 CustomButton(action: {
-                    viewModel.showingAlert2 = true
+                    viewModel.send(action: .showAlert2)
                 }, font: .suite, title: "열람실 이용 연장", titleColor: .white, backgroundColor: .customBlue100, leading: 0, trailing: 0)
                 
                 Spacer().frame(height: UIScreen.UIHeight(12))
                 
                 CustomButton(action: {
-                    viewModel.showingAlert = true
+                    viewModel.send(action: .showAlert)
                 }, font: .suite, title: "열람실 이용 종료", titleColor: .customGray100, backgroundColor: .customGray600, leading: 0, trailing: 0)
             } else {
                 HStack {
@@ -42,7 +42,7 @@ struct HomeView: View {
                     Spacer().frame(width: UIScreen.UIWidth(12))
                     
                     CustomButton2(action: {
-                        viewModel.showingDialog = true
+                        viewModel.send(action: .showDialog)
                     }, title: "열람실 이용 시작", image: .angularButton02, maxWidth: .infinity, minHeight: 52)
                 }
                 
@@ -80,12 +80,11 @@ struct HomeView: View {
         .dialog(isPresented: $viewModel.showingDialog,
                 currentDate: $viewModel.useageStartTime,
                 confirmAction: {
-            viewModel.startRoomUsage()
-            print("확인버튼 눌림")
+            viewModel.send(action: .startUsing)
         }, cancelAction: {
         })
         .alert(title: "열람실을 다 이용하셨나요?", confirmButtonText: "네", cancleButtonText: "더 이용하기", isPresented: $viewModel.showingAlert, confirmAction: {
-            viewModel.cancleRoomUsage()
+            viewModel.send(action: .useCompleted)
         }, cancelAction: {
             
         })

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct HomeView: View {
+    
     @State private var showCompleteAlert = false
     @State private var showTimeExtensionAlert = false
     @State private var showingDialog = false
@@ -24,7 +25,8 @@ struct HomeView: View {
             if timerViewModel.isStart {
                 TimeLapse(startTime: timerViewModel.startTime,
                           endTime: timerViewModel.endTime,
-                          timeRemaining: timerViewModel.timeRemaining)
+                          timeRemaining: timerViewModel.timeRemaining,
+                          totalTime: calendarViewModel.todayStudyTime)
             } else {
                 Quote()
             }

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -89,23 +89,30 @@ struct HomeView: View {
             timerViewModel.send(action: .startButtonTap)
         }
         .alert(title: "열람실을 다 이용하셨나요?", confirmButtonText: "네", cancleButtonText: "더 이용하기", isPresented: $showCompleteAlert) {
-            // 타이머 중지
-            timerViewModel.send(action: .completeButtonTap)
-            
-            // 총시간
-            let totalTime = timerViewModel.totalTime
-            let data = StudyRecord(date: Date(), totalTime: totalTime)
-            
-            // 캘린더 업데이트
-            calendarViewModel.send(action: .saveButtonTap(data))
+            saveData()
         }
         .alert(title: "열람실 이용 시간을 연장할까요?", confirmButtonText: "연장하기", cancleButtonText: "아니오", isPresented: $showTimeExtensionAlert) {
             timerViewModel.send(action: .addTimeButtonTap)
         }
+        .onReceive(timerViewModel.$timeRemaining.filter { $0 <= 0 }) { _ in
+            saveData()
+        }
+    }
+    
+    func saveData() {
+        // 타이머 중지
+        timerViewModel.send(action: .completeButtonTap)
+        
+        // 총시간
+        let totalTime = timerViewModel.totalTime
+        let data = StudyRecord(date: Date(), totalTime: totalTime)
+        
+        // 캘린더 업데이트
+        calendarViewModel.send(action: .saveButtonTap(data))
     }
 }
 
 
-#Preview {
-    HomeView()
-}
+//#Preview {
+//    HomeView()
+//}

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -97,10 +97,10 @@ struct HomeView: View {
             let data = StudyRecord(date: Date(), totalTime: totalTime)
             
             // 캘린더 업데이트
-            calendarViewModel.send(action: .saveData(data))
+            calendarViewModel.send(action: .saveButtonTap(data))
         }
         .alert(title: "열람실 이용 시간을 연장할까요?", confirmButtonText: "연장하기", cancleButtonText: "아니오", isPresented: $showTimeExtensionAlert) {
-            
+            timerViewModel.send(action: .addTimeButtonTap)
         }
     }
 }

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeView.swift
@@ -8,8 +8,13 @@
 import SwiftUI
 
 struct HomeView: View {
+    @State private var showCompleteAlert = false
+    @State private var showTimeExtensionAlert = false
+    @State private var showingDialog = false
+    
     @EnvironmentObject private var coordinator: SceneCoordinator
     @EnvironmentObject private var timerViewModel: TimerViewModel
+    @EnvironmentObject private var calendarViewModel: CalendarViewModel
     
     var body: some View {
         VStack(spacing: 0) {
@@ -29,13 +34,13 @@ struct HomeView: View {
             
             if timerViewModel.isStart {
                 CustomButton(action: {
-                    timerViewModel.send(action: .showAlert2)
+                    showTimeExtensionAlert = true
                 }, font: .suite, title: "열람실 이용 연장", titleColor: .white, backgroundColor: .customBlue100, leading: 0, trailing: 0)
                 
                 Spacer().frame(height: UIScreen.UIHeight(12))
                 
                 CustomButton(action: {
-                    timerViewModel.send(action: .showAlert)
+                    showCompleteAlert = true
                 }, font: .suite, title: "열람실 이용 종료", titleColor: .customGray100, backgroundColor: .customGray600, leading: 0, trailing: 0)
             } else {
                 HStack {
@@ -44,7 +49,7 @@ struct HomeView: View {
                     Spacer().frame(width: UIScreen.UIWidth(12))
                     
                     CustomButton2(action: {
-                        timerViewModel.send(action: .showDialog)
+                        showingDialog = true
                     }, title: "열람실 이용 시작", image: .angularButton02, maxWidth: .infinity, minHeight: 52)
                 }
                 
@@ -79,14 +84,22 @@ struct HomeView: View {
                 Image(.icHamburger)
             })
         })
-        .dialog(isPresented: $timerViewModel.showingDialog,
+        .dialog(isPresented: $showingDialog,
                 currentDate: $timerViewModel.startTime) {
-            timerViewModel.send(action: .startUsing)
+            timerViewModel.send(action: .startButtonTap)
         }
-        .alert(title: "열람실을 다 이용하셨나요?", confirmButtonText: "네", cancleButtonText: "더 이용하기", isPresented: $timerViewModel.showingAlert) {
-            timerViewModel.send(action: .useCompleted)
+        .alert(title: "열람실을 다 이용하셨나요?", confirmButtonText: "네", cancleButtonText: "더 이용하기", isPresented: $showCompleteAlert) {
+            // 타이머 중지
+            timerViewModel.send(action: .completeButtonTap)
+            
+            // 총시간
+            let totalTime = timerViewModel.totalTime
+            let data = StudyRecord(date: Date(), totalTime: totalTime)
+            
+            // 캘린더 업데이트
+            calendarViewModel.send(action: .saveData(data))
         }
-        .alert(title: "열람실 이용 시간을 연장할까요?", confirmButtonText: "연장하기", cancleButtonText: "아니오", isPresented: $timerViewModel.showingAlert2) {
+        .alert(title: "열람실 이용 시간을 연장할까요?", confirmButtonText: "연장하기", cancleButtonText: "아니오", isPresented: $showTimeExtensionAlert) {
             
         }
     }

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeViewModel.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeViewModel.swift
@@ -7,12 +7,21 @@
 
 import Foundation
 
-final class HomeViewModel: ObservableObject {
+final class HomeViewModel: ViewModelType {
     @Published var isRoomReserved = false
     @Published var useageStartTime = Date()
     @Published var showingAlert = false
     @Published var showingAlert2 = false
     @Published var showingDialog = false
+        
+    @Inject var calendarRepository: CalendarRepositoryType
+    
+    
+    enum Action {}
+    
+    func send(action: Action) {
+        
+    }
     
     func startRoomUsage() {
         isRoomReserved = true

--- a/HongikYeolgong2-iOS/Scene/Container/Home/HomeViewModel.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/HomeViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 final class HomeViewModel: ViewModelType {
-    @Published var isRoomReserved = false
+    @Published var isBooked = false
     @Published var useageStartTime = Date()
     @Published var showingAlert = false
     @Published var showingAlert2 = false
@@ -17,17 +17,26 @@ final class HomeViewModel: ViewModelType {
     @Inject var calendarRepository: CalendarRepositoryType
     
     
-    enum Action {}
+    enum Action {
+        case startUsing
+        case showDialog
+        case showAlert
+        case showAlert2
+        case useCompleted
+    }
     
     func send(action: Action) {
-        
-    }
-    
-    func startRoomUsage() {
-        isRoomReserved = true
-    }
-    
-    func cancleRoomUsage() {
-        isRoomReserved = false
+        switch action {
+        case .startUsing:
+            isBooked = true
+        case .showDialog:
+            showingDialog = true
+        case .showAlert:
+            showingAlert = true
+        case .showAlert2:
+            showingAlert2 = true
+        case .useCompleted:
+            break
+        }
     }
 }

--- a/HongikYeolgong2-iOS/Scene/Container/Home/TimerViewModel.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/TimerViewModel.swift
@@ -1,16 +1,16 @@
 //
-//  HomeViewModel.swift
+//  TimerViewModel.swift
 //  HongikYeolgong2-iOS
 //
-//  Created by 석기권 on 7/11/24.
+//  Created by 석기권 on 7/24/24.
 //
 
 import Foundation
 import Combine
 
-final class HomeViewModel: ViewModelType {
+final class TimerViewModel: ViewModelType {
     // State
-    @Published var isBooked = false
+    @Published var isStart = false
     @Published var startTime = Date()
     @Published var endTime: Date!
     @Published var showingAlert = false
@@ -21,8 +21,6 @@ final class HomeViewModel: ViewModelType {
     private let timer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
     
     private var cancellables = Set<AnyCancellable>()
-    
-    @Inject var calendarRepository: CalendarRepositoryType
     
     // Input
     enum Action {
@@ -37,7 +35,7 @@ final class HomeViewModel: ViewModelType {
     func send(action: Action) {
         switch action {
         case .startUsing:
-            isBooked = true
+            isStart = true
             endTime = startTime + TimeInterval(3600 * 6)
             timeRemaining = Int(endTime.timeIntervalSince(startTime))
             
@@ -53,8 +51,9 @@ final class HomeViewModel: ViewModelType {
         case .showAlert2:
             showingAlert2 = true
         case .useCompleted:
-            isBooked = false
+            isStart = false
             cancellables.removeAll()
         }
     }
 }
+

--- a/HongikYeolgong2-iOS/Scene/Container/Home/TimerViewModel.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/TimerViewModel.swift
@@ -13,7 +13,7 @@ final class TimerViewModel: ViewModelType {
     @Published var isStart = false
     @Published var startTime = Date()
     @Published var endTime: Date!
-    @Published var timeRemaining = 0
+    @Published var timeRemaining = 123456
     @Published var totalTime = 0
     
     private let timer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
@@ -31,24 +31,36 @@ final class TimerViewModel: ViewModelType {
     func send(action: Action) {
         switch action {
         case .startButtonTap:
-            isStart = true
-            endTime = startTime + TimeInterval(3600 * 6)
-            timeRemaining = Int(endTime.timeIntervalSince(startTime))
-            
-            timer.sink { [weak self] _ in
-                guard let self = self else { return }
-                timeRemaining -= 1
-            }
-            .store(in: &cancellables)
+            startTimer()
         case .completeButtonTap:
-            cancellables.removeAll()
-            isStart = false
-            totalTime = Int(endTime.timeIntervalSince(startTime)) - timeRemaining         
+            saveTime()
         case .addTimeButtonTap:
-            totalTime = Int(endTime.timeIntervalSince(startTime)) - timeRemaining
-            endTime = endTime + TimeInterval(3600 * 6)            
-            timeRemaining = Int(endTime.timeIntervalSince(startTime)) - totalTime
+            addTime()
         }
+    }
+    
+    func startTimer() {
+        isStart = true
+        endTime = startTime + TimeInterval(10)
+        timeRemaining = Int(endTime.timeIntervalSince(startTime))
+        
+        timer.sink { [weak self] _ in
+            guard let self = self else { return }
+            timeRemaining -= 1
+        }
+        .store(in: &cancellables)
+    }
+    
+    func saveTime() {
+        cancellables.removeAll()
+        isStart = false
+        totalTime = Int(endTime.timeIntervalSince(startTime)) - timeRemaining
+    }
+    
+    func addTime() {
+        totalTime = Int(endTime.timeIntervalSince(startTime)) - timeRemaining
+        endTime = endTime + TimeInterval(3600 * 6)
+        timeRemaining = Int(endTime.timeIntervalSince(startTime)) - totalTime
     }
 }
 

--- a/HongikYeolgong2-iOS/Scene/Container/Home/TimerViewModel.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/TimerViewModel.swift
@@ -13,10 +13,8 @@ final class TimerViewModel: ViewModelType {
     @Published var isStart = false
     @Published var startTime = Date()
     @Published var endTime: Date!
-    @Published var showingAlert = false
-    @Published var showingAlert2 = false
-    @Published var showingDialog = false
     @Published var timeRemaining = 0
+    @Published var totalTime = 0
     
     private let timer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
     
@@ -24,17 +22,14 @@ final class TimerViewModel: ViewModelType {
     
     // Input
     enum Action {
-        case startUsing
-        case showDialog
-        case showAlert
-        case showAlert2
-        case useCompleted
+        case startButtonTap
+        case completeButtonTap
     }
     
     // Binding
     func send(action: Action) {
         switch action {
-        case .startUsing:
+        case .startButtonTap:
             isStart = true
             endTime = startTime + TimeInterval(3600 * 6)
             timeRemaining = Int(endTime.timeIntervalSince(startTime))
@@ -44,15 +39,10 @@ final class TimerViewModel: ViewModelType {
                 timeRemaining -= 1
             }
             .store(in: &cancellables)
-        case .showDialog:
-            showingDialog = true
-        case .showAlert:
-            showingAlert = true
-        case .showAlert2:
-            showingAlert2 = true
-        case .useCompleted:
-            isStart = false
+        case .completeButtonTap:
             cancellables.removeAll()
+            isStart = false
+            totalTime = Int(endTime.timeIntervalSince(startTime)) - timeRemaining                       
         }
     }
 }

--- a/HongikYeolgong2-iOS/Scene/Container/Home/TimerViewModel.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/TimerViewModel.swift
@@ -24,6 +24,7 @@ final class TimerViewModel: ViewModelType {
     enum Action {
         case startButtonTap
         case completeButtonTap
+        case addTimeButtonTap
     }
     
     // Binding
@@ -42,7 +43,11 @@ final class TimerViewModel: ViewModelType {
         case .completeButtonTap:
             cancellables.removeAll()
             isStart = false
-            totalTime = Int(endTime.timeIntervalSince(startTime)) - timeRemaining                       
+            totalTime = Int(endTime.timeIntervalSince(startTime)) - timeRemaining         
+        case .addTimeButtonTap:
+            totalTime = Int(endTime.timeIntervalSince(startTime)) - timeRemaining
+            endTime = endTime + TimeInterval(3600 * 6)            
+            timeRemaining = Int(endTime.timeIntervalSince(startTime)) - totalTime
         }
     }
 }

--- a/HongikYeolgong2-iOS/Scene/Container/Home/TimerViewModel.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Home/TimerViewModel.swift
@@ -18,7 +18,7 @@ final class TimerViewModel: ViewModelType {
     
     private let timer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
     
-    private var cancellables = Set<AnyCancellable>()
+    private var subscriptions = Set<AnyCancellable>()
     
     // Input
     enum Action {
@@ -48,11 +48,11 @@ final class TimerViewModel: ViewModelType {
             guard let self = self else { return }
             timeRemaining -= 1
         }
-        .store(in: &cancellables)
+        .store(in: &subscriptions)
     }
     
     func saveTime() {
-        cancellables.removeAll()
+        subscriptions.removeAll()
         isStart = false
         totalTime = Int(endTime.timeIntervalSince(startTime)) - timeRemaining
     }

--- a/HongikYeolgong2-iOS/Scene/Container/Ready/TimeLapse.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Ready/TimeLapse.swift
@@ -12,6 +12,7 @@ struct TimeLapse: View {
     let startTime: Date
     let endTime: Date
     let timeRemaining: Int
+    let totalTime: Int
     
     var body: some View {
         VStack(spacing: 0) {
@@ -72,9 +73,9 @@ struct TimeLapse: View {
                 Spacer()
                 
                 HStack {
-                    Image(.shineCount00)
-                    Image(.shineCount00)
-                    Image(.shineCount00)
+                    Image(totalTime >= 10 ? .shineCount01 : .shineCount00)
+                    Image(totalTime >= 20 ? .shineCount02 : .shineCount00)
+                    Image(totalTime >= 30 ? .shineCount03 : .shineCount00)
                 }
             }
         }
@@ -94,5 +95,5 @@ extension Int {
 }
 
 #Preview {
-    TimeLapse(startTime: Date(), endTime: Date(), timeRemaining: 0)
+    TimeLapse(startTime: Date(), endTime: Date(), timeRemaining: 0, totalTime: 0)
 }

--- a/HongikYeolgong2-iOS/Scene/Container/Ready/TimeLapse.swift
+++ b/HongikYeolgong2-iOS/Scene/Container/Ready/TimeLapse.swift
@@ -11,6 +11,7 @@ struct TimeLapse: View {
     
     let startTime: Date
     let endTime: Date
+    let timeRemaining: Int
     
     var body: some View {
         VStack(spacing: 0) {
@@ -66,7 +67,7 @@ struct TimeLapse: View {
                 .frame(height: UIScreen.UIHeight(11))
             
             HStack {
-                CustomText(font: .suite, title: "03:52:00", textColor: .customGray100, textWeight: .extrabold, textSize: 30)
+                CustomText(font: .suite, title: timeRemaining.getFullTimeString(), textColor: timeRemaining <= (1800) ? .customYellow100 : .customGray100, textWeight: .extrabold, textSize: 30)
                 
                 Spacer()
                 
@@ -80,6 +81,18 @@ struct TimeLapse: View {
     }
 }
 
+extension Int {
+    func getFullTimeString() -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute, .second]
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = .pad
+        let formattedString = formatter.string(from: TimeInterval(self))!
+        return formattedString
+    }
+    
+}
+
 #Preview {
-    TimeLapse(startTime: Date(), endTime: Date())
+    TimeLapse(startTime: Date(), endTime: Date(), timeRemaining: 0)
 }


### PR DESCRIPTION
## AS-IS
열람실 이용시간 데이터를 받아오는 코드를 ViewModel에 작성하게 되면 테스트 확장성 및 유지보수성이 떨어집니다.
## TO-BE
Presentation과 Data 사이에 Repository라는 레이어를 추가했습니다. ViewModel과 데이터를 받아오는 Repository를 별도로 구현하여 각각 테스트 및 기능확장이 가능합니다.
## KEY-POINT
Reopository 추가
- Repository는 DIContainer로 주입하여 사용합니다.
- Repository는 특정 구현체에 의존하지 않고 추상적인 인터페이스에 의존합니다.

![스크린샷 2024-07-25 오후 12 02 20](https://github.com/user-attachments/assets/8fc89ea3-2c58-459f-8007-3a36cae1ee9c)
CalendarRepository는 CalendarRepositoryType 프로토콜을 채택합니다. 추후에 Firebase 연동시 모듈 교체가 용이합니다.

Model 구조
![스크린샷 2024-07-25 오후 12 04 55](https://github.com/user-attachments/assets/6c19acef-36c2-4cb8-9dbb-fee162dfc05e)
기존에 Day 구조체에 studyRecord라는 배열 속성을 추가했습니다. StudyRecord는 날짜를 저장하는 date와 이용시간이 초단위로 저장됩니다. 아직 시간 또는 이용횟수로 정해지지 않은 상태라서 추후에 변동이 될 수 있습니다.

이용시간 6시간을 기준으로 했을때 UI변경 확인이 어려워서 이용시간을 10초로 설정했습니다.
## SCREENSHOT (Optional)
